### PR TITLE
feat: add recording duration measure

### DIFF
--- a/docs/source/reference/measures.rst
+++ b/docs/source/reference/measures.rst
@@ -15,6 +15,7 @@ Measures
     data_loss
     dispersion
     disposition
+    duration
     location
     null_ratio
     peak_velocity

--- a/src/pymovements/gaze/_utils/_parsing_eyelink.py
+++ b/src/pymovements/gaze/_utils/_parsing_eyelink.py
@@ -608,8 +608,9 @@ def parse_eyelink(
     calibrations = []
     recording_config: list[dict[str, Any]] = []
     samples_config: list[dict[str, Any]] = []
-
+    start_recording_timestamp: str | None = None
     total_recording_duration = 0.0
+
     is_binocular = False
 
     # Single pass: collect events, patterns, samples, samples config, and metadata
@@ -692,16 +693,17 @@ def parse_eyelink(
             start_recording_timestamp = match.groupdict()['timestamp']
 
         elif match := _match_regex(STOP_RECORDING_REGEX, line):
-            stop_recording_timestamp = match.groupdict()['timestamp']
-
-            try:
-                float(stop_recording_timestamp) - float(start_recording_timestamp)
-            except UnboundLocalError:
+            if start_recording_timestamp is None:
                 warnings.warn(
                     'END recording message without associated START recording message. '
                     f"File '{filepath}' may be corrupted. "
-                    'Total recording duration may be incorrect.',
+                    'Recording intervals may be incomplete.',
                 )
+            else:
+                total_recording_duration += (
+                    float(match.groupdict()['timestamp']) - float(start_recording_timestamp)
+                )
+            start_recording_timestamp = None
         if messages and (match := _match_regex(MSG_REGEX, line)):
             messages_list.append([match.groupdict()['timestamp'], match.groupdict()['content']])
 
@@ -838,6 +840,7 @@ def parse_eyelink(
     pre_processed_metadata['calibrations'] = calibrations
     pre_processed_metadata['validations'] = validations
     pre_processed_metadata['recording_config'] = recording_config
+    pre_processed_metadata['total_recording_duration_ms'] = total_recording_duration
 
     gaze_schema_overrides = {
         'time': pl.Float64,

--- a/src/pymovements/gaze/_utils/_parsing_eyelink.py
+++ b/src/pymovements/gaze/_utils/_parsing_eyelink.py
@@ -695,16 +695,13 @@ def parse_eyelink(
             stop_recording_timestamp = match.groupdict()['timestamp']
 
             try:
-                block_duration = float(stop_recording_timestamp) - float(start_recording_timestamp)
+                float(stop_recording_timestamp) - float(start_recording_timestamp)
             except UnboundLocalError:
                 warnings.warn(
                     'END recording message without associated START recording message. '
                     f"File '{filepath}' may be corrupted. "
                     'Total recording duration may be incorrect.',
                 )
-            else:  # this will only be executed if no exception was raised in the try block.
-                total_recording_duration += block_duration
-
         if messages and (match := _match_regex(MSG_REGEX, line)):
             messages_list.append([match.groupdict()['timestamp'], match.groupdict()['content']])
 
@@ -841,7 +838,6 @@ def parse_eyelink(
     pre_processed_metadata['calibrations'] = calibrations
     pre_processed_metadata['validations'] = validations
     pre_processed_metadata['recording_config'] = recording_config
-    pre_processed_metadata['total_recording_duration_ms'] = total_recording_duration
 
     gaze_schema_overrides = {
         'time': pl.Float64,

--- a/src/pymovements/gaze/_utils/_parsing_eyelink.py
+++ b/src/pymovements/gaze/_utils/_parsing_eyelink.py
@@ -581,7 +581,6 @@ def parse_eyelink(
     recording_config: list[dict[str, Any]] = []
     samples_config: list[dict[str, Any]] = []
 
-    total_recording_duration = 0.0
     # First pass: collect SAMPLES config for binocular detection only
     is_binocular = False
     for line in lines:
@@ -696,16 +695,13 @@ def parse_eyelink(
             stop_recording_timestamp = match.groupdict()['timestamp']
 
             try:
-                block_duration = float(stop_recording_timestamp) - float(start_recording_timestamp)
+                float(stop_recording_timestamp) - float(start_recording_timestamp)
             except UnboundLocalError:
                 warnings.warn(
                     'END recording message without associated START recording message. '
                     f"File '{filepath}' may be corrupted. "
                     'Total recording duration may be incorrect.',
                 )
-            else:  # this will only be executed if no exception was raised in the try block.
-                total_recording_duration += block_duration
-
         if messages and (match := _match_regex(MSG_REGEX, line)):
             messages_list.append([match.groupdict()['timestamp'], match.groupdict()['content']])
 
@@ -842,7 +838,6 @@ def parse_eyelink(
     pre_processed_metadata['calibrations'] = calibrations
     pre_processed_metadata['validations'] = validations
     pre_processed_metadata['recording_config'] = recording_config
-    pre_processed_metadata['total_recording_duration_ms'] = total_recording_duration
 
     gaze_schema_overrides = {
         'time': pl.Float64,

--- a/src/pymovements/measure/samples/__init__.py
+++ b/src/pymovements/measure/samples/__init__.py
@@ -25,6 +25,7 @@ from pymovements.measure.samples.measures import bcea
 from pymovements.measure.samples.measures import data_loss
 from pymovements.measure.samples.measures import dispersion
 from pymovements.measure.samples.measures import disposition
+from pymovements.measure.samples.measures import duration
 from pymovements.measure.samples.measures import location
 from pymovements.measure.samples.measures import null_ratio
 from pymovements.measure.samples.measures import peak_velocity
@@ -41,6 +42,7 @@ __all__ = [
     'data_loss',
     'dispersion',
     'disposition',
+    'duration',
     'location',
     'null_ratio',
     'peak_velocity',

--- a/src/pymovements/measure/samples/measures.py
+++ b/src/pymovements/measure/samples/measures.py
@@ -203,9 +203,11 @@ def duration(*, time_column: str = 'time') -> pl.Expr:
     """Duration spanned by a group of samples.
 
     The duration is defined as the difference between the maximum and minimum
-    timestamps in the group. When used with :meth:`pymovements.Gaze.measure_samples`,
-    the duration is calculated for the complete recording or separately for each
-    trial, depending on whether trial columns are configured.
+    timestamps in the group. The result is expressed in the unit of the time
+    column (usually milliseconds). When used with
+    :meth:`~pymovements.Gaze.measure_samples`, the duration is calculated for
+    the complete recording or separately for each trial, depending on whether
+    trial columns are configured.
 
     This measures only the observed sample span. It can be shorter than the
     EyeLink ``START``-to-``END`` recording span when samples are absent because

--- a/src/pymovements/measure/samples/measures.py
+++ b/src/pymovements/measure/samples/measures.py
@@ -207,6 +207,10 @@ def duration(*, time_column: str = 'time') -> pl.Expr:
     the duration is calculated for the complete recording or separately for each
     trial, depending on whether trial columns are configured.
 
+    This measures only the observed sample span. It can be shorter than the
+    EyeLink ``START``-to-``END`` recording span when samples are absent because
+    of blinks, gaps, or filtering.
+
     Parameters
     ----------
     time_column: str

--- a/src/pymovements/measure/samples/measures.py
+++ b/src/pymovements/measure/samples/measures.py
@@ -199,6 +199,29 @@ def dispersion(
 
 
 @register_sample_measure
+def duration(*, time_column: str = 'time') -> pl.Expr:
+    """Duration spanned by a group of samples.
+
+    The duration is defined as the difference between the maximum and minimum
+    timestamps in the group. When used with :meth:`pymovements.Gaze.measure_samples`,
+    the duration is calculated for the complete recording or separately for each
+    trial, depending on whether trial columns are configured.
+
+    Parameters
+    ----------
+    time_column: str
+        Name of the timestamp column. (default: 'time')
+
+    Returns
+    -------
+    pl.Expr
+        The duration of the sample group.
+    """
+    timestamps = pl.col(time_column)
+    return (timestamps.max() - timestamps.min()).alias('duration')
+
+
+@register_sample_measure
 def disposition(
         *,
         position_column: str = 'position',

--- a/tests/unit/gaze/_utils/_parsing_eyelink_test.py
+++ b/tests/unit/gaze/_utils/_parsing_eyelink_test.py
@@ -220,7 +220,6 @@ EXPECTED_METADATA_EYELINK = {
     'validations': [],
     'resolution': (1280.0, 1024.0),
     'DISPLAY_COORDS': (0.0, 0.0, 1279.0, 1023.0),
-    'total_recording_duration_ms': 12.0,
     'datetime': datetime.datetime(2023, 3, 8, 9, 25, 20),
     'mount_configuration': {
         'mount_type': 'Desktop',
@@ -1153,7 +1152,7 @@ def test_parse_eyelink_stop_recording_calculates_expected_samples(make_text_file
     """Write a minimal asc file with RECCFG, START, and END to exercise recording_config block.
 
     The RECCFG line provides a sampling rate of 1000 Hz and the START/END span 1000 ms,
-    so expected number of samples = 1000 and total_recording_duration_ms should be 1000.0.
+    so the expected number of samples is 1000.
     """
     content = (
         'MSG 0 RECCFG CR 1000 0 0 LR\n'
@@ -1167,8 +1166,7 @@ def test_parse_eyelink_stop_recording_calculates_expected_samples(make_text_file
     with pytest.warns(UserWarning):
         _, _, metadata, _ = _parsing_eyelink.parse_eyelink(str(p))
 
-    # Duration should be 1000 ms
-    assert metadata['total_recording_duration_ms'] == 1000.0
+    assert 'total_recording_duration_ms' not in metadata
 
 
 def test_check_reccfg_key_warns_on_empty_config() -> None:

--- a/tests/unit/gaze/_utils/_parsing_eyelink_test.py
+++ b/tests/unit/gaze/_utils/_parsing_eyelink_test.py
@@ -220,7 +220,6 @@ EXPECTED_METADATA_EYELINK = {
     'validations': [],
     'resolution': (1280.0, 1024.0),
     'DISPLAY_COORDS': (0.0, 0.0, 1279.0, 1023.0),
-    'total_recording_duration_ms': 12.0,
     'datetime': datetime.datetime(2023, 3, 8, 9, 25, 20),
     'mount_configuration': {
         'mount_type': 'Desktop',
@@ -1119,7 +1118,7 @@ def test_parse_eyelink_stop_recording_calculates_expected_samples(make_text_file
     """Write a minimal asc file with RECCFG, START, and END to exercise recording_config block.
 
     The RECCFG line provides a sampling rate of 1000 Hz and the START/END span 1000 ms,
-    so expected number of samples = 1000 and total_recording_duration_ms should be 1000.0.
+    so the expected number of samples is 1000.
     """
     content = (
         'MSG 0 RECCFG CR 1000 0 0 LR\n'
@@ -1133,8 +1132,7 @@ def test_parse_eyelink_stop_recording_calculates_expected_samples(make_text_file
     with pytest.warns(UserWarning):
         _, _, metadata, _ = _parsing_eyelink.parse_eyelink(str(p))
 
-    # Duration should be 1000 ms
-    assert metadata['total_recording_duration_ms'] == 1000.0
+    assert 'total_recording_duration_ms' not in metadata
 
 
 def test_check_reccfg_key_warns_on_empty_config() -> None:

--- a/tests/unit/gaze/_utils/_parsing_eyelink_test.py
+++ b/tests/unit/gaze/_utils/_parsing_eyelink_test.py
@@ -1150,7 +1150,11 @@ def test_recording_config_missing_sampling_rate_key(monkeypatch, make_text_file)
 
 
 def test_parse_eyelink_stop_recording_preserves_duration_metadata(make_text_file):
-    """Write a minimal asc file with RECCFG, START, and END."""
+    """A matched START/END pair sets total_recording_duration_ms from message timestamps.
+
+    The file contains no samples, so the expected 1000.0 (END at 1000 ms minus
+    START at 0 ms) can only come from the START/END messages.
+    """
     content = (
         'MSG 0 RECCFG CR 1000 0 0 LR\n'
         'START 0 RIGHT types\n'

--- a/tests/unit/gaze/_utils/_parsing_eyelink_test.py
+++ b/tests/unit/gaze/_utils/_parsing_eyelink_test.py
@@ -220,6 +220,7 @@ EXPECTED_METADATA_EYELINK = {
     'validations': [],
     'resolution': (1280.0, 1024.0),
     'DISPLAY_COORDS': (0.0, 0.0, 1279.0, 1023.0),
+    'total_recording_duration_ms': 12.0,
     'datetime': datetime.datetime(2023, 3, 8, 9, 25, 20),
     'mount_configuration': {
         'mount_type': 'Desktop',
@@ -1148,12 +1149,8 @@ def test_recording_config_missing_sampling_rate_key(monkeypatch, make_text_file)
         _, _, _, _ = _parsing_eyelink.parse_eyelink(filepath)
 
 
-def test_parse_eyelink_stop_recording_calculates_expected_samples(make_text_file):
-    """Write a minimal asc file with RECCFG, START, and END to exercise recording_config block.
-
-    The RECCFG line provides a sampling rate of 1000 Hz and the START/END span 1000 ms,
-    so the expected number of samples is 1000.
-    """
+def test_parse_eyelink_stop_recording_preserves_duration_metadata(make_text_file):
+    """Write a minimal asc file with RECCFG, START, and END."""
     content = (
         'MSG 0 RECCFG CR 1000 0 0 LR\n'
         'START 0 RIGHT types\n'
@@ -1166,7 +1163,7 @@ def test_parse_eyelink_stop_recording_calculates_expected_samples(make_text_file
     with pytest.warns(UserWarning):
         _, _, metadata, _ = _parsing_eyelink.parse_eyelink(str(p))
 
-    assert 'total_recording_duration_ms' not in metadata
+    assert metadata['total_recording_duration_ms'] == 1000.0
 
 
 def test_check_reccfg_key_warns_on_empty_config() -> None:
@@ -1551,6 +1548,21 @@ def test_parse_eyelink_unmatched_stop_recording_warns(make_text_file):
 END 20 SAMPLES EVENTS RES 0 0
 """
     filepath = make_text_file('unmatched_stop.asc', body=asc_content)
+
+    with pytest.warns(UserWarning, match='END recording message without associated START'):
+        _parsing_eyelink.parse_eyelink(filepath)
+
+
+@pytest.mark.filterwarnings('ignore:No metadata found.')
+@pytest.mark.filterwarnings('ignore:No samples configuration found.')
+def test_parse_eyelink_second_unmatched_stop_recording_warns(make_text_file):
+    """Test that a second STOP recording message cannot reuse an earlier START message."""
+    asc_content = """MSG 10 RECCFG CR 1000 2 1 L
+START 15 SAMPLES EVENTS
+END 20 SAMPLES EVENTS RES 0 0
+END 30 SAMPLES EVENTS RES 0 0
+"""
+    filepath = make_text_file('second_unmatched_stop.asc', body=asc_content)
 
     with pytest.warns(UserWarning, match='END recording message without associated START'):
         _parsing_eyelink.parse_eyelink(filepath)

--- a/tests/unit/gaze/measure_test.py
+++ b/tests/unit/gaze/measure_test.py
@@ -300,6 +300,30 @@ def my_test_measure(column: str) -> pl.Expr:
 
         pytest.param(
             {
+                'samples': pl.DataFrame({'time': [10, 15, 12]}),
+            },
+            'duration',
+            {},
+            pl.DataFrame({'duration': [5]}),
+            id='duration_complete_gaze',
+        ),
+
+        pytest.param(
+            {
+                'samples': pl.DataFrame({
+                    'time': [10, 15, 20, 28],
+                    'trial': [1, 1, 2, 2],
+                }),
+                'trial_columns': 'trial',
+            },
+            'duration',
+            {},
+            pl.DataFrame({'trial': [1, 2], 'duration': [5, 8]}),
+            id='duration_two_trials',
+        ),
+
+        pytest.param(
+            {
                 'samples': pl.from_dict(
                     data={
                         'A': [1000, 1001, 1002, 1003],

--- a/tests/unit/measure/samples/library_test.py
+++ b/tests/unit/measure/samples/library_test.py
@@ -32,6 +32,7 @@ from pymovements.measure import samples
         pytest.param(samples.amplitude, 'amplitude', id='amplitude'),
         pytest.param(samples.dispersion, 'dispersion', id='dispersion'),
         pytest.param(samples.disposition, 'disposition', id='disposition'),
+        pytest.param(samples.duration, 'duration', id='duration'),
         pytest.param(samples.location, 'location', id='location'),
         pytest.param(samples.null_ratio, 'null_ratio', id='null_ratio'),
         pytest.param(samples.peak_velocity, 'peak_velocity', id='peak_velocity'),

--- a/tests/unit/measure/samples/measures/duration_test.py
+++ b/tests/unit/measure/samples/measures/duration_test.py
@@ -47,6 +47,16 @@ from pymovements.measure.samples import duration
             id='single_sample',
         ),
         pytest.param(
+            {},
+            pl.DataFrame({
+                'time': pl.Series([1000, 1250, 1750], dtype=pl.Duration('us')),
+            }),
+            pl.DataFrame({
+                'duration': pl.Series([750], dtype=pl.Duration('us')),
+            }),
+            id='duration_timestamps',
+        ),
+        pytest.param(
             {'time_column': 'timestamp'},
             pl.DataFrame({'timestamp': [5, 9]}),
             pl.DataFrame({'duration': [4]}),

--- a/tests/unit/measure/samples/measures/duration_test.py
+++ b/tests/unit/measure/samples/measures/duration_test.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Test duration sample measure."""
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from pymovements.measure.samples import duration
+
+
+@pytest.mark.parametrize(
+    ('init_kwargs', 'input_df', 'expected_df'),
+    [
+        pytest.param(
+            {},
+            pl.DataFrame({'time': [1000, 1001, 1004]}),
+            pl.DataFrame({'duration': [4]}),
+            id='integer_timestamps',
+        ),
+        pytest.param(
+            {},
+            pl.DataFrame({'time': [10.5, 4.0, 8.0]}),
+            pl.DataFrame({'duration': [6.5]}),
+            id='float_unsorted_timestamps',
+        ),
+        pytest.param(
+            {},
+            pl.DataFrame({'time': [42]}),
+            pl.DataFrame({'duration': [0]}),
+            id='single_sample',
+        ),
+        pytest.param(
+            {'time_column': 'timestamp'},
+            pl.DataFrame({'timestamp': [5, 9]}),
+            pl.DataFrame({'duration': [4]}),
+            id='custom_time_column',
+        ),
+    ],
+)
+def test_duration_has_expected_result(init_kwargs, input_df, expected_df):
+    result_df = input_df.select(duration(**init_kwargs))
+
+    assert_frame_equal(result_df, expected_df)
+
+
+def test_duration_raises_for_missing_time_column():
+    expression = duration(time_column='missing')
+
+    with pytest.raises(pl.exceptions.ColumnNotFoundError, match='missing'):
+        pl.DataFrame({'time': [0, 1]}).select(expression)


### PR DESCRIPTION
## Description

Add a registered sample-level duration measure that works for a complete `Gaze` or per trial. The measure uses the observed timestamp span (`max - min`) and replaces the EyeLink-specific `total_recording_duration_ms` metadata calculation.

The private metadata key is removed as requested by #1585. Downstream consumers that read it directly will need to migrate to `Gaze.measure_samples('duration')`. This is a breaking change: the new measure spans observed samples, while the removed field summed EyeLink `START`-to-`END` blocks, so gaps, blinks, or filtered samples can make the new value shorter.

## Implemented changes

- [x] Add and register `pymovements.measure.samples.duration`
- [x] Cover direct, whole-Gaze, per-trial, and `polars.Duration` behavior
- [x] Remove the legacy EyeLink duration metadata field
- [x] Preserve explicit warnings for unmatched EyeLink recording blocks
- [x] Publish the sample measure in the API documentation

## How Has This Been Tested?

- [x] Focused affected suite: 170 passed
- [x] Full warning-as-error documentation build: `tox -e docs -- -aE`
- [x] All changed-file pre-commit hooks, including mypy and pylint
- [x] `git diff --check`

A broader unit run was sampled without failures but was not completed; all affected measure, registry, Gaze, and EyeLink parser tests completed successfully.

## Type of change

- New functionality
- Breaking change
- Documentation update

## Context

Resolves partially #1585 (fully resolving the issue is blocked by #1663)

#### related issues:
- #1608 touches adjacent EyeLink parser code but deliberately retains this duration field for the present follow-up.
- #1637 changes the `time` column to `polars.Duration`; this PR includes direct duration-typed coverage without depending on that PR.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the change is effective
- [x] I have checked my code and corrected any misspellings
