### PR TITLE
docs: remove OSF recommendation

### DIFF
--- a/docs/source/contributing/contributing-datasets.ipynb
+++ b/docs/source/contributing/contributing-datasets.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "**pymovements does not _host_ datasets**, it only provides an interface for downloading and reading them. Therefore, you will need to upload your dataset somewhere, such that pymovements will be able to download it.\n",
     "\n",
-    "- Your data must be openly available and downloadable from a simple link without requiring additional steps like logging in. We recommend [OSF](https://osf.io/) for hosting your files, but other platforms like Zenodo or GitHub will also work.\n",
+    "- Your data must be openly available and downloadable from a simple link without requiring additional steps like logging in. We recommend an open research data repository like [Zenodo](https://zenodo.org/) for hosting your files, but platforms like GitHub will also work.\n",
     "- Your data must be stored in one of the supported formats: CSV, ASC (EyeLink), IPC/Feather.\n",
     "- Your dataset may consist of multiple files, including ZIP files containing nested folders.\n",
     "- Trial information (e.g., trial or participant IDs) may be stored as additional columns in the data files, in the filenames, or as messages in ASC files."


### PR DESCRIPTION
## Description

Starting in February 2027, OSF will [drop support for sharing public datasets](https://www.cos.io/blog/osf-changes-a-note-to-users). Existing public datasets will continue to be available.