### PR TITLE
feat: add 'first' and 'last' as methods to location measure

### DIFF
--- a/src/pymovements/measure/samples/measures.py
+++ b/src/pymovements/measure/samples/measures.py
@@ -266,11 +266,15 @@ def location(
         \text{Location} = \text{median} \left(\text{position}_1, \ldots,
          \text{position}_n \right)
 
+    For methods ``start`` and ``end`` the location is the position of the first and last sample in
+    the event, respectively.
+
 
     Parameters
     ----------
     method: str
-        The centroid method to be used for calculation. Supported methods are ``mean``, ``median``.
+        The centroid method to be used for calculation. Supported methods are ``mean``, ``median``,
+        ``first``, and ``last``.
         (default: 'mean')
     position_column: str
         The column name of the position tuples. (default: 'position')
@@ -288,10 +292,10 @@ def location(
     ValueError
         If method is not one of the supported methods.
     """
-    if method not in {'mean', 'median'}:
+    if method not in {'mean', 'median', 'first', 'last'}:
         raise ValueError(
             f"Method '{method}' not supported. "
-            f"Please choose one of the following: ['mean', 'median'].",
+            f"Please choose one of the following: ['mean', 'median', 'first', 'last'].",
         )
 
     component_expressions = []
@@ -304,8 +308,12 @@ def location(
 
         if method == 'mean':
             expression_component = position_component.mean()
-        else:  # by exclusion this must be median
+        elif method == 'median':
             expression_component = position_component.median()
+        elif method == 'first':
+            expression_component = position_component.first()
+        else:  # by exclusion this must be last
+            expression_component = position_component.last()
 
         component_expressions.append(expression_component)
 

--- a/tests/unit/measure/samples/measures/location_test.py
+++ b/tests/unit/measure/samples/measures/location_test.py
@@ -82,6 +82,32 @@ def test_location_exceptions(init_kwargs, exception, message):
             ),
             id='position_three_samples_median',
         ),
+
+        pytest.param(
+            {'method': 'first'},
+            pl.DataFrame(
+                {'position': [[0, 0], [2, 1], [3, 3]]},
+                schema={'position': pl.List(pl.Float64)},
+            ),
+            pl.DataFrame(
+                {'location': [[0, 0]]},
+                schema={'location': pl.List(pl.Float64)},
+            ),
+            id='position_three_samples_first',
+        ),
+
+        pytest.param(
+            {'method': 'last'},
+            pl.DataFrame(
+                {'position': [[0, 0], [2, 1], [3, 3]]},
+                schema={'position': pl.List(pl.Float64)},
+            ),
+            pl.DataFrame(
+                {'location': [[3, 3]]},
+                schema={'location': pl.List(pl.Float64)},
+            ),
+            id='position_three_samples_last',
+        ),
     ],
 )
 def test_location_has_expected_result(init_kwargs, input_df, expected_df):


### PR DESCRIPTION
## Description

Knowing the start and end of a saccade (or maybe blink) could be useful. This basically uses the first and last samples in the event (assuming that the samples are already ordered by timestamp -- is this an assumption we make generally?).

## Implemented changes

- [x] Add `first` and `last` as methods for location measure.

## How Has This Been Tested?

- [x] Add `first` and `last` methods to existing unit test parameters

## Type of change

- New functionality

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
