### PR TITLE
feat: specify column names in `compute_event_properties()`

### DIFF
--- a/src/pymovements/gaze/gaze.py
+++ b/src/pymovements/gaze/gaze.py
@@ -1298,6 +1298,7 @@ class Gaze:
             self,
             event_properties: str | tuple[str, dict[str, Any]]
             | list[str | tuple[str, dict[str, Any]]],
+            column_names: str | list[str] | None = None,
             name: str | None = None,
     ) -> None:
         """Calculate event properties for given events.
@@ -1309,6 +1310,9 @@ class Gaze:
         ----------
         event_properties: str | tuple[str, dict[str, Any]] | list[str | tuple[str, dict[str, Any]]]
             The event properties to compute.
+        column_names: str | list[str] | None
+            The name(s) of the column(s) to be added to the event dataframe. If None, columns will
+            be named after the event properties. (default: None)
         name: str | None
             Process only events that match the name. (default: None)
 
@@ -1319,6 +1323,9 @@ class Gaze:
             :ref:`event-measures` for an overview of supported measures.
         RuntimeError
             If specified event name ``name`` is missing from ``events``.
+        ValueError
+            If ``column_names`` has a different length than ``event_properties``, or if there are
+            duplicate column names.
         """
         if len(self.events) == 0:
             warn(
@@ -1328,7 +1335,7 @@ class Gaze:
 
         identifiers = self.trial_columns if self.trial_columns is not None else []
 
-        processor = EventSamplesProcessor(event_properties)
+        processor = EventSamplesProcessor(event_properties, column_names=column_names)
         results = processor.process(
             self.events.frame, self.samples, identifiers=identifiers, name=name,
         )

--- a/src/pymovements/gaze/gaze.py
+++ b/src/pymovements/gaze/gaze.py
@@ -1298,7 +1298,7 @@ class Gaze:
             self,
             event_properties: str | tuple[str, dict[str, Any]]
             | list[str | tuple[str, dict[str, Any]]],
-            column_names: str | list[str] | None = None,
+            column_names: str | list[str | None] | None = None,
             name: str | None = None,
     ) -> None:
         """Calculate event properties for given events.
@@ -1310,7 +1310,7 @@ class Gaze:
         ----------
         event_properties: str | tuple[str, dict[str, Any]] | list[str | tuple[str, dict[str, Any]]]
             The event properties to compute.
-        column_names: str | list[str] | None
+        column_names: str | list[str | None] | None
             The name(s) of the column(s) to be added to the event dataframe. If None, columns will
             be named after the event properties. (default: None)
         name: str | None

--- a/src/pymovements/measure/events/processing.py
+++ b/src/pymovements/measure/events/processing.py
@@ -88,7 +88,7 @@ class EventSamplesProcessor:
     ----------
     measures: str | tuple[str, dict[str, Any]] | list[str | tuple[str, dict[str, Any]]]
         List of sample measures.
-    column_names: str | list[str] | None
+    column_names: str | list[str | None] | None
         The name(s) of the column(s) to be added to the event dataframe. If None, columns will
         be named after the sample measures. (default: None)
 
@@ -106,7 +106,7 @@ class EventSamplesProcessor:
             self,
             measures: str | tuple[str, dict[str, Any]]
             | list[str | tuple[str, dict[str, Any]]],
-            column_names: str | list[str] | None = None,
+            column_names: str | list[str | None] | None = None,
     ):
         _check_measures(measures)
 
@@ -133,12 +133,18 @@ class EventSamplesProcessor:
         if column_names is not None and len(column_names) != len(measures_with_kwargs):
             raise ValueError("Number of 'column_names' must match number of 'measures'.")
         if column_names is None:
-            column_names = [
-                SampleMeasureLibrary.get(measure_name)(**measure_kwargs).meta.output_name()
-                for measure_name, measure_kwargs in measures_with_kwargs
-            ]
-        if len(column_names) != len(set(column_names)):
-            duplicates = {name for name in column_names if column_names.count(name) > 1}
+            column_names = [None] * len(measures_with_kwargs)
+        # Check for duplicates in eventual column names.
+        evaluated_column_names = [
+            measure_name if column_name is None else column_name
+            for (measure_name, _), column_name in zip(measures_with_kwargs, column_names)
+        ]
+        if len(evaluated_column_names) != len(set(evaluated_column_names)):
+            duplicates = {
+                name
+                for name in evaluated_column_names
+                if isinstance(name, str) and evaluated_column_names.count(name) > 1
+            }
             raise ValueError(
                 f"Duplicate column names found: {', '.join(duplicates)}. "
                 "Use 'column_names' to specify unique names for each measure.",
@@ -146,9 +152,13 @@ class EventSamplesProcessor:
 
         self.measures: list[pl.Expr] = [
             # initialize measure functions to create polars expressions.
-            SampleMeasureLibrary.get(measure_name)(**measure_kwargs).alias(column_name)
-            for (measure_name, measure_kwargs), column_name
-            in zip(measures_with_kwargs, column_names)
+            SampleMeasureLibrary.get(measure_name)(**measure_kwargs)
+            for (measure_name, measure_kwargs) in measures_with_kwargs
+        ]
+        # Re-alias measures to the specified column names.
+        self.measures = [
+            measure.alias(column_name) if column_name is not None else measure
+            for measure, column_name in zip(self.measures, column_names)
         ]
 
     def process(

--- a/src/pymovements/measure/events/processing.py
+++ b/src/pymovements/measure/events/processing.py
@@ -88,18 +88,25 @@ class EventSamplesProcessor:
     ----------
     measures: str | tuple[str, dict[str, Any]] | list[str | tuple[str, dict[str, Any]]]
         List of sample measures.
+    column_names: str | list[str] | None
+        The name(s) of the column(s) to be added to the event dataframe. If None, columns will
+        be named after the sample measures. (default: None)
 
     Raises
     ------
     UnknownMeasure
         If ``event_properties`` includes an unknown measure. See :ref:`sample-measures` and
         :ref:`event-measures` for an overview of supported measures.
+    ValueError
+        If ``column_names`` has a different length than ``measures``, or if there are
+        duplicate column names.
     """
 
     def __init__(
             self,
             measures: str | tuple[str, dict[str, Any]]
             | list[str | tuple[str, dict[str, Any]]],
+            column_names: str | list[str] | None = None,
     ):
         _check_measures(measures)
 
@@ -121,10 +128,27 @@ class EventSamplesProcessor:
                     measure_name=measure_name, known_measures=known_measures,
                 )
 
+        if isinstance(column_names, str):
+            column_names = [column_names]
+        if column_names is not None and len(column_names) != len(measures_with_kwargs):
+            raise ValueError("Number of 'column_names' must match number of 'measures'.")
+        if column_names is None:
+            column_names = [
+                SampleMeasureLibrary.get(measure_name)(**measure_kwargs).meta.output_name()
+                for measure_name, measure_kwargs in measures_with_kwargs
+            ]
+        if len(column_names) != len(set(column_names)):
+            duplicates = {name for name in column_names if column_names.count(name) > 1}
+            raise ValueError(
+                f"Duplicate column names found: {', '.join(duplicates)}. "
+                "Use 'column_names' to specify unique names for each measure.",
+            )
+
         self.measures: list[pl.Expr] = [
             # initialize measure functions to create polars expressions.
-            SampleMeasureLibrary.get(measure_name)(**measure_kwargs)
-            for measure_name, measure_kwargs in measures_with_kwargs
+            SampleMeasureLibrary.get(measure_name)(**measure_kwargs).alias(column_name)
+            for (measure_name, measure_kwargs), column_name
+            in zip(measures_with_kwargs, column_names)
         ]
 
     def process(


### PR DESCRIPTION
## Description

Adds an argument `column_names` to `Gaze.compute_event_properties()` through which the user can specify the names of the columns that will be added to `Event.frame`. This allows the user to compute the same property several times (e.g., with different parameters, or on different events) by giving each a different column name. When the argumen tis not provided, the default behavior is still the same.

## Implemented changes

Insert a description of the changes implemented in the pull request.

- [x] Add `column_names` argument to `Gaze.compute_event_properties()`
- [x] Add `column_names` argument to `EventSamplesProcessor.__init__()`
- [ ] Add `column_names` argument to `EventProcessor.__init__()`

## How Has This Been Tested?

- [ ] TODO

## Type of change

- New functionality

## Context

Resolves #1043

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
