### PR TITLE
feat: officially add python 3.14 support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key:
-            benchmark-ubuntu-latest-py313-${{ hashFiles('tox.ini', 'pyproject.toml', '.github/workflows/benchmark.yml') }}
+            benchmark-ubuntu-latest-py314-${{ hashFiles('tox.ini', 'pyproject.toml', '.github/workflows/benchmark.yml') }}
           path: |
             ~/.cache
             ~/.tox
@@ -33,7 +33,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tox
         run: python -m pip install tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
 
     - name: Install build dependency
       run: python -m pip install build

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install pymovements
         run: python -m pip install -e ${{ github.workspace }}
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key:
-            datasets-ubuntu-latest-py313-${{ hashFiles('tox.ini', 'pyproject.toml', '.github/workflows/datasets') }}
+            datasets-ubuntu-latest-py314-${{ hashFiles('tox.ini', 'pyproject.toml', '.github/workflows/datasets') }}
           path: |
             ~/.cache
             ~/.tox
@@ -63,7 +63,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tox
         run: python -m pip install tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         is_main:
           - ${{ contains(github.ref, 'main') }}
         exclude:
@@ -40,6 +41,8 @@ jobs:
             python: "3.11"
           - is_main: false
             python: "3.12"
+          - is_main: false
+            python: "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed"
 ]

--- a/src/pymovements/dataset/websource.py
+++ b/src/pymovements/dataset/websource.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from dataclasses import KW_ONLY
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError
 from urllib.error import URLError
 from warnings import warn
 
@@ -323,6 +324,8 @@ def _get_redirected_url(url: str, max_hops: int = 3) -> str:
     ------
     RuntimeError
         If number of redirects exceed `max_hops`.
+    HTTPError
+        If the server returns an HTTP error status.
     """
     initial_url = url
     headers = {'Method': 'HEAD', 'User-Agent': USER_AGENT}
@@ -331,7 +334,15 @@ def _get_redirected_url(url: str, max_hops: int = 3) -> str:
     urllib.request.install_opener(opener)
 
     for _ in range(max_hops + 1):
-        with urllib.request.urlopen(urllib.request.Request(url, headers=headers)) as response:
+        try:
+            response = urllib.request.urlopen(urllib.request.Request(url, headers=headers))
+        except HTTPError as e:
+            # Close explicitly, otherwise the buffered error response leaks a temporary file
+            # on Python 3.14, causing a ResourceWarning during garbage collection.
+            e.close()
+            raise
+
+        with response:
             if response.url == url or response.url is None:
                 return url
             url = response.url
@@ -393,5 +404,11 @@ def _download_url(url: str, destination: Path, verbose: bool = True) -> None:
         If True, show progressbar.
     """
     with _DownloadProgressBar(desc=destination.name, disable=not verbose) as t:
-        urllib.request.urlretrieve(url=url, filename=destination, reporthook=t.update_to)
+        try:
+            urllib.request.urlretrieve(url=url, filename=destination, reporthook=t.update_to)
+        except HTTPError as e:
+            # Close explicitly, otherwise the buffered error response leaks a temporary file
+            # on Python 3.14, causing a ResourceWarning during garbage collection.
+            e.close()
+            raise
         t.total = t.n

--- a/tests/unit/dataset/websource_test.py
+++ b/tests/unit/dataset/websource_test.py
@@ -19,12 +19,15 @@
 # SOFTWARE.
 """Tests for WebSource and download utilities."""
 import hashlib
+import io
 from pathlib import Path
 from unittest import mock
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 import pytest
 
+from pymovements.dataset.websource import _download_url
 from pymovements.dataset.websource import _DownloadProgressBar
 from pymovements.dataset.websource import _get_redirected_url
 from pymovements.dataset.websource import ChecksumError
@@ -369,6 +372,30 @@ def test__get_redirected_url_with_redirects_max_hops():
         'https://github.com/pymovements/pymovements/archive/master.zip '\
         'exceeded 0 redirects. The last redirect points to '\
         'https://codeload.github.com/pymovements/pymovements/zip/main.'
+
+
+def test__get_redirected_url_http_error_closes_response():
+    url = 'http://example.com/file.zip'
+    http_error = HTTPError(url=url, code=404, msg='Not Found', hdrs=None, fp=io.BytesIO(b''))
+
+    with mock.patch.object(http_error, 'close', wraps=http_error.close) as mock_close:
+        with mock.patch('urllib.request.urlopen', side_effect=http_error):
+            with pytest.raises(HTTPError):
+                _get_redirected_url(url)
+
+    mock_close.assert_called_once()
+
+
+def test__download_url_http_error_closes_response(tmp_path):
+    url = 'http://example.com/file.zip'
+    http_error = HTTPError(url=url, code=404, msg='Not Found', hdrs=None, fp=io.BytesIO(b''))
+
+    with mock.patch.object(http_error, 'close', wraps=http_error.close) as mock_close:
+        with mock.patch('urllib.request.urlretrieve', side_effect=http_error):
+            with pytest.raises(HTTPError):
+                _download_url(url, tmp_path / 'file.zip', verbose=False)
+
+    mock_close.assert_called_once()
 
 
 def test__DownloadProgressBar_tsize_not_None():

--- a/tests/unit/dataset/websource_test.py
+++ b/tests/unit/dataset/websource_test.py
@@ -27,7 +27,6 @@ from urllib.error import HTTPError
 
 import pytest
 
-from pymovements.dataset.websource import _download_url
 from pymovements.dataset.websource import _DownloadProgressBar
 from pymovements.dataset.websource import _get_redirected_url
 from pymovements.dataset.websource import ChecksumError
@@ -374,26 +373,35 @@ def test__get_redirected_url_with_redirects_max_hops():
         'https://codeload.github.com/pymovements/pymovements/zip/main.'
 
 
-def test__get_redirected_url_http_error_closes_response():
-    url = 'http://example.com/file.zip'
-    http_error = HTTPError(url=url, code=404, msg='Not Found', hdrs=None, fp=io.BytesIO(b''))
+def test_websource_download_http_error_on_redirect_closes_response(tmp_path):
+    source = WebSource(url='http://example.com/file.zip', filename='file.zip')
+    http_error = HTTPError(
+        url=source.url, code=404, msg='Not Found', hdrs=None, fp=io.BytesIO(b''),
+    )
 
     with mock.patch.object(http_error, 'close', wraps=http_error.close) as mock_close:
         with mock.patch('urllib.request.urlopen', side_effect=http_error):
-            with pytest.raises(HTTPError):
-                _get_redirected_url(url)
+            with pytest.raises(RuntimeError, match=f'Downloading resource {source.url} failed'):
+                source.download(tmp_path, verbose=False)
 
     mock_close.assert_called_once()
 
 
-def test__download_url_http_error_closes_response(tmp_path):
-    url = 'http://example.com/file.zip'
-    http_error = HTTPError(url=url, code=404, msg='Not Found', hdrs=None, fp=io.BytesIO(b''))
+def test_websource_download_http_error_on_retrieve_closes_response(tmp_path):
+    source = WebSource(url='http://example.com/file.zip', filename='file.zip')
+    http_error = HTTPError(
+        url=source.url, code=404, msg='Not Found', hdrs=None, fp=io.BytesIO(b''),
+    )
+    mock_response = mock.MagicMock()
+    mock_response.url = source.url
 
     with mock.patch.object(http_error, 'close', wraps=http_error.close) as mock_close:
-        with mock.patch('urllib.request.urlretrieve', side_effect=http_error):
-            with pytest.raises(HTTPError):
-                _download_url(url, tmp_path / 'file.zip', verbose=False)
+        with mock.patch('urllib.request.urlopen', return_value=mock_response):
+            with mock.patch('urllib.request.urlretrieve', side_effect=http_error):
+                with pytest.raises(
+                        RuntimeError, match=f'Downloading resource {source.url} failed',
+                ):
+                    source.download(tmp_path, verbose=False)
 
     mock_close.assert_called_once()
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py311
     py312
     py313
+    py314
     benchmark
     build
     docs


### PR DESCRIPTION
## Description

Adds Python 3.14 to the supported versions and adapts the codebase to run cleanly on it. Python 3.14 becomes the default version for the build, benchmark and datasets workflows.

The only code change needed is in `websource.py`: on Python 3.14, an `HTTPError` raised by `urllib` holds a buffered error response backed by a temporary file. If the error object is not closed explicitly, the file leaks and triggers a `ResourceWarning` during garbage collection, which fails our warning-strict tests.

## Implemented changes

- [x] Explicitly close `HTTPError` responses in `_get_redirected_url()` and `_download_url()` to avoid leaked temporary files on Python 3.14
- [x] Add `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`
- [x] Add `py314` to the tox envlist
- [x] Add 3.14 to the CI test matrix
- [x] Bump default Python from 3.13 to 3.14 in `build.yml`, `benchmark.yml` and `datasets.yml`

## Context

Resolves #1372

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
