### PR TITLE
feat(plotting): Add screen canvas

### DIFF
--- a/src/pymovements/plotting/__init__.py
+++ b/src/pymovements/plotting/__init__.py
@@ -22,6 +22,7 @@ from pymovements.plotting.data_loss_histogram import data_loss_histogram
 from pymovements.plotting.heatmap import heatmap
 from pymovements.plotting.main_sequence_plot import main_sequence_plot
 from pymovements.plotting.scanpathplot import scanpathplot
+from pymovements.plotting.screen import screen
 from pymovements.plotting.traceplot import traceplot
 from pymovements.plotting.tsplot import tsplot
 
@@ -30,6 +31,7 @@ __all__ = [
     'heatmap',
     'main_sequence_plot',
     'scanpathplot',
+    'screen',
     'traceplot',
     'tsplot',
 ]

--- a/src/pymovements/plotting/_matplotlib.py
+++ b/src/pymovements/plotting/_matplotlib.py
@@ -37,7 +37,6 @@ from matplotlib.collections import LineCollection
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import FancyArrowPatch
 
-from pymovements.gaze.experiment import Screen
 
 LinearSegmentedColormapType: TypeAlias = dict[
     Literal['red', 'green', 'blue', 'alpha'],
@@ -301,41 +300,3 @@ def _draw_line_data(
     line_collection.set_linewidth(2)
     line = ax.add_collection(line_collection)
     return line
-
-
-def _set_screen_axes(
-    ax: plt.Axes,
-    screen: Screen,
-    *,
-    func_name: str,
-) -> None:
-    """Set axes limits and aspect ratio from gaze.experiment.screen, if available.
-
-    Parameters
-    ----------
-    ax : plt.Axes
-        Matplotlib axes object to modify.
-    screen : Screen
-        Screen object from a Gaze's Experiment.
-    func_name : str
-        Name of the plotting function, used in error messages.
-
-    Raises
-    ------
-    ValueError
-        If the screen origin is not 'upper left'.
-    ValueError
-        If the screen width or height is not positive.
-    """
-    # If screen has no pixel info, skip silently
-    if screen.width_px is None or screen.height_px is None:
-        return
-
-    if screen.origin != 'upper left':
-        raise ValueError(
-            f'{func_name}: screen origin must be "upper left", got "{screen.origin}".',
-        )
-
-    ax.set_xlim(0, screen.width_px)
-    ax.set_ylim(screen.height_px, 0)
-    ax.set_aspect('equal', adjustable='box')

--- a/src/pymovements/plotting/heatmap.py
+++ b/src/pymovements/plotting/heatmap.py
@@ -28,8 +28,8 @@ import numpy as np
 from matplotlib import colors
 
 from pymovements.gaze import Gaze
-from pymovements.plotting._matplotlib import _set_screen_axes
 from pymovements.plotting._matplotlib import prepare_figure
+from pymovements.plotting.screen import screen as screen_canvas
 from pymovements.stimulus.image import _draw_image_stimulus
 
 
@@ -220,7 +220,8 @@ def heatmap(
     heatmap_plot.set_alpha(np.where(heatmap_plot.get_array().data > 0, alpha, 0.0))
 
     # Apply screen-based axis limits and aspect ratio
-    _set_screen_axes(ax, gaze.experiment.screen, func_name='heatmap')
+    display = gaze.experiment.screen
+    screen_canvas(display.width_px, display.height_px, origin=display.origin, ax=ax)
 
     # Set the plot title and axis labels
     if title:

--- a/src/pymovements/plotting/scanpathplot.py
+++ b/src/pymovements/plotting/scanpathplot.py
@@ -33,9 +33,9 @@ from pymovements.events import Events
 from pymovements.gaze import Gaze
 from pymovements.plotting._matplotlib import _draw_arrow_data
 from pymovements.plotting._matplotlib import _draw_line_data
-from pymovements.plotting._matplotlib import _set_screen_axes
 from pymovements.plotting._matplotlib import _setup_axes_and_colormap
 from pymovements.plotting._matplotlib import LinearSegmentedColormapType
+from pymovements.plotting.screen import screen as screen_canvas
 
 
 def scanpathplot(
@@ -239,7 +239,8 @@ def scanpathplot(
         )
 
     if gaze is not None and gaze.experiment is not None:
-        _set_screen_axes(ax, gaze.experiment.screen, func_name='scanpathplot')
+        display = gaze.experiment.screen
+        screen_canvas(display.width_px, display.height_px, origin=display.origin, ax=ax)
 
     if title:
         ax.set_title(title)

--- a/src/pymovements/plotting/screen.py
+++ b/src/pymovements/plotting/screen.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-2026 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Create an empty display-space canvas."""
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+
+
+def screen(
+        width_px: int | None,
+        height_px: int | None,
+        *,
+        origin: str | None = 'upper left',
+        ax: plt.Axes | None = None,
+) -> tuple[plt.Figure, plt.Axes]:
+    """Create an empty axes configured for display-space coordinates.
+
+    Screen coordinates increase downward for both supported origins. Therefore,
+    images drawn on the returned axes should use ``origin='upper'``.
+
+    Parameters
+    ----------
+    width_px : int | None
+        Width of the display in pixels.
+    height_px : int | None
+        Height of the display in pixels.
+    origin : str | None
+        Coordinate-system origin. Supported values are ``'upper left'`` and
+        ``'center'``. (default: ``'upper left'``)
+    ax : plt.Axes | None
+        Existing axes to configure. A new figure and axes are created when unset.
+
+    Returns
+    -------
+    tuple[plt.Figure, plt.Axes]
+        Figure and configured axes.
+
+    Raises
+    ------
+    ValueError
+        If either display dimension is unset.
+    ValueError
+        If the origin is unset or unsupported.
+    """
+    if width_px is None or height_px is None:
+        raise ValueError('screen width_px and height_px must be set.')
+
+    if origin not in {'upper left', 'center'}:
+        raise ValueError(
+            f'screen origin must be "upper left" or "center", got "{origin}".',
+        )
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+
+    if origin == 'upper left':
+        ax.set_xlim(0, width_px)
+        ax.set_ylim(height_px, 0)
+    else:
+        ax.set_xlim(-width_px / 2, width_px / 2)
+        ax.set_ylim(height_px / 2, -height_px / 2)
+
+    ax.set_aspect('equal', adjustable='box')
+    return fig, ax

--- a/src/pymovements/plotting/traceplot.py
+++ b/src/pymovements/plotting/traceplot.py
@@ -28,9 +28,9 @@ import numpy as np
 
 from pymovements.gaze.gaze import Gaze
 from pymovements.plotting._matplotlib import _draw_line_data
-from pymovements.plotting._matplotlib import _set_screen_axes
 from pymovements.plotting._matplotlib import _setup_axes_and_colormap
 from pymovements.plotting._matplotlib import LinearSegmentedColormapType
+from pymovements.plotting.screen import screen as screen_canvas
 
 
 def traceplot(
@@ -162,7 +162,8 @@ def traceplot(
     )
 
     if gaze is not None and gaze.experiment is not None:
-        _set_screen_axes(ax, gaze.experiment.screen, func_name='traceplot')
+        display = gaze.experiment.screen
+        screen_canvas(display.width_px, display.height_px, origin=display.origin, ax=ax)
 
     if show_cbar:
         # sm = matplotlib.cm.ScalarMappable(cmap=cmap, norm=cmap_norm)

--- a/tests/unit/plotting/heatmap_test.py
+++ b/tests/unit/plotting/heatmap_test.py
@@ -222,10 +222,10 @@ def test_heatmap_sets_screen_axes_correctly(gaze):
     assert ax.get_aspect() == 1.0
 
 
-@pytest.mark.parametrize('origin', ['lower left', 'center', 'upper right'])
+@pytest.mark.parametrize('origin', ['lower left', 'upper right'])
 def test_heatmap_invalid_screen_origin_raises(origin, gaze):
     gaze.experiment.screen.origin = origin
-    with pytest.raises(ValueError, match='screen origin must be "upper left"'):
+    with pytest.raises(ValueError, match='screen origin must be'):
         pm.plotting.heatmap(gaze)
 
 

--- a/tests/unit/plotting/scanpathplot_test.py
+++ b/tests/unit/plotting/scanpathplot_test.py
@@ -342,10 +342,10 @@ def test_set_screen_axes_valid(gaze):
     assert ax.get_aspect() == 1
 
 
-@pytest.mark.parametrize('origin', ['lower left', 'center'])
+@pytest.mark.parametrize('origin', ['lower left', 'upper right'])
 def test_set_screen_axes_invalid_origin(origin, gaze):
     gaze.experiment.screen.origin = origin
-    with pytest.raises(ValueError, match='screen origin must be "upper left"'):
+    with pytest.raises(ValueError, match='screen origin must be'):
         scanpathplot(gaze=gaze)
 
 
@@ -357,24 +357,12 @@ def test_set_screen_axes_invalid_origin(origin, gaze):
         (1024, None),
     ],
 )
-def test_set_screen_axes_none_dimensions_returns(width, height, gaze):
-    """Should not raise or override axes when screen dimensions are None."""
+def test_set_screen_axes_none_dimensions_raises(width, height, gaze):
     gaze.experiment.screen.width_px = width
     gaze.experiment.screen.height_px = height
 
-    _, ax = plt.subplots()
-
-    # Call scanpathplot; should return silently, without ValueError
-    # _set_screen_axes() should return early without modifying axes
-    scanpathplot(gaze=gaze, ax=ax, figsize=None)
-
-    # Axes limits should be finite numbers, not NaN/None
-    xlim, ylim = ax.get_xlim(), ax.get_ylim()
-    assert np.isfinite(xlim).all()
-    assert np.isfinite(ylim).all()
-
-    # Aspect ratio should not be 'equal' (not forced by _set_screen_axes)
-    assert ax.get_aspect() != 'equal'
+    with pytest.raises(ValueError, match='width_px and height_px must be set'):
+        scanpathplot(gaze=gaze)
 
 
 def test_scanpathplot_with_image_stimulus(gaze, tmp_path):

--- a/tests/unit/plotting/screen_test.py
+++ b/tests/unit/plotting/screen_test.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023-2026 The pymovements Project Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Tests for the display-space canvas."""
+import matplotlib.pyplot as plt
+import pytest
+
+from pymovements import plotting
+
+
+@pytest.mark.parametrize(
+    ('origin', 'expected_xlim', 'expected_ylim'),
+    [
+        pytest.param('upper left', (0, 1920), (1080, 0), id='upper-left'),
+        pytest.param('center', (-960, 960), (540, -540), id='center'),
+    ],
+)
+def test_screen_extent_and_orientation(origin, expected_xlim, expected_ylim):
+    fig, ax = plotting.screen(1920, 1080, origin=origin)
+
+    assert ax.figure is fig
+    assert ax.get_xlim() == expected_xlim
+    assert ax.get_ylim() == expected_ylim
+    assert ax.get_aspect() == 1
+    assert not ax.lines
+    assert not ax.collections
+    assert not ax.images
+    assert not ax.patches
+
+
+def test_screen_reuses_axes():
+    expected_fig, expected_ax = plt.subplots()
+
+    fig, ax = plotting.screen(800, 600, ax=expected_ax)
+
+    assert fig is expected_fig
+    assert ax is expected_ax
+
+
+@pytest.mark.parametrize(
+    ('width_px', 'height_px'),
+    [
+        pytest.param(None, 1080, id='missing-width'),
+        pytest.param(1920, None, id='missing-height'),
+        pytest.param(None, None, id='missing-both'),
+    ],
+)
+def test_screen_unset_resolution_raises(width_px, height_px):
+    with pytest.raises(ValueError, match='width_px and height_px must be set'):
+        plotting.screen(width_px, height_px)
+
+
+@pytest.mark.parametrize('origin', [None, 'lower left', 'upper right'])
+def test_screen_invalid_origin_raises(origin):
+    with pytest.raises(ValueError, match='origin must be'):
+        plotting.screen(1920, 1080, origin=origin)

--- a/tests/unit/plotting/traceplot_test.py
+++ b/tests/unit/plotting/traceplot_test.py
@@ -231,10 +231,10 @@ def test_set_screen_axes_valid(gaze):
     assert ax.get_aspect() == 1
 
 
-@pytest.mark.parametrize('origin', ['lower left', 'center', 'upper right'])
+@pytest.mark.parametrize('origin', ['lower left', 'upper right'])
 def test_set_screen_axes_invalid_origin(origin, gaze):
     gaze.experiment.screen.origin = origin
-    with pytest.raises(ValueError, match='screen origin must be "upper left"'):
+    with pytest.raises(ValueError, match='screen origin must be'):
         traceplot(gaze=gaze)
 
 
@@ -246,24 +246,12 @@ def test_set_screen_axes_invalid_origin(origin, gaze):
         (1024, None),
     ],
 )
-def test_set_screen_axes_none_dimensions_returns(width, height, gaze):
-    """Should not raise or override axes when screen dimensions are None."""
+def test_set_screen_axes_none_dimensions_raises(width, height, gaze):
     gaze.experiment.screen.width_px = width
     gaze.experiment.screen.height_px = height
 
-    _, ax = plt.subplots()
-    assert ax.get_aspect() != 'equal'
-    # Call traceplot; should return silently, without ValueError
-    # _set_screen_axes() should return early without modifying axes
-    traceplot(gaze=gaze, ax=ax, figsize=None)
-
-    # Axes limits should be finite numbers, not NaN/None
-    xlim, ylim = ax.get_xlim(), ax.get_ylim()
-    assert np.isfinite(xlim).all()
-    assert np.isfinite(ylim).all()
-
-    # Aspect ratio should not be 'equal' (not forced by _set_screen_axes)
-    assert ax.get_aspect() != 'equal'
+    with pytest.raises(ValueError, match='width_px and height_px must be set'):
+        traceplot(gaze=gaze)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add a public primitive-based display canvas helper and migrate the existing gaze plotters to use it. The helper centralizes pixel extents and origin orientation without importing domain classes into the plotting internals.

## Implemented changes

- [x] Add `plotting.screen()` for new or existing axes
- [x] Support upper-left and centered screen origins with downward-increasing y coordinates
- [x] Migrate `traceplot`, `scanpathplot`, and `heatmap` and remove the `Screen` dependency from `_matplotlib.py`
- [x] Raise clear errors for missing dimensions and unsupported origins
- [x] Add focused unit coverage and update migrated caller expectations

## How Has This Been Tested?

- [x] `python -m pytest tests/unit/plotting/screen_test.py tests/unit/plotting/traceplot_test.py tests/unit/plotting/scanpathplot_test.py tests/unit/plotting/heatmap_test.py -q` (`298 passed`)
- [x] `pre-commit run --files ...` for all changed files (all hooks passed)

## Type of change

- New functionality
- Breaking change: plotters now raise when screen pixel dimensions are unset, as specified by the issue

## Context

Resolves #1703

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing relevant unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings