### PR TITLE
Render property docstrings in API reference

### DIFF
--- a/docs/source/_templates/class.rst
+++ b/docs/source/_templates/class.rst
@@ -17,3 +17,15 @@
    {% endblock %}
 
    {% block attributes %}{% endblock %}
+
+   {% set properties = property_members.get(module ~ '.' ~ objname, []) %}
+   {% if properties %}
+   .. rubric:: {{ _('Properties') }}
+
+   .. autosummary::
+      :toctree:
+      :template: property.rst
+   {% for item in attributes if item in properties %}
+      ~{{ objname }}.{{ item }}
+   {%- endfor %}
+   {% endif %}

--- a/docs/source/_templates/property.rst
+++ b/docs/source/_templates/property.rst
@@ -1,0 +1,6 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoproperty:: {{ objname }}
+   :no-index:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,7 @@
 import importlib.resources
 import inspect
 import os
+import pkgutil
 import string
 import sys
 from subprocess import CalledProcessError
@@ -95,6 +96,29 @@ def doctree_resolved_handler(app, doctree, docname):
         if uri.startswith(('http://', 'https://')):
             node['target'] = '_blank'
             node['rel'] = 'noopener noreferrer'
+
+
+def collect_property_members():
+    """Collect property names for every importable pymovements class path."""
+    package = importlib.import_module('pymovements')
+    modules = [package]
+    for module_info in pkgutil.walk_packages(package.__path__, f'{package.__name__}.'):
+        try:
+            modules.append(importlib.import_module(module_info.name))
+        except ImportError:
+            continue
+
+    property_members = {}
+    for module in modules:
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            properties = [
+                member_name
+                for member_name in dir(obj)
+                if isinstance(inspect.getattr_static(obj, member_name), property)
+            ]
+            if properties:
+                property_members[f'{module.__name__}.{name}'] = properties
+    return property_members
 
 
 def setup(app):
@@ -202,6 +226,7 @@ nitpick_ignore_regex = [
 autosummary_generate = True
 autosummary_generate_overwrite = True
 autosummary_imported_members = False
+autosummary_context = {'property_members': collect_property_members()}
 add_module_names = True
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,7 @@ def collect_property_members():
             properties = [
                 member_name
                 for member_name in dir(obj)
-                if isinstance(inspect.getattr_static(obj, member_name), property)
+                if isinstance(inspect.getattr_static(obj, member_name, None), property)
             ]
             if properties:
                 property_members[f'{module.__name__}.{name}'] = properties


### PR DESCRIPTION
## Summary
- collect property members for autosummary without exposing plain data attributes
- add a dedicated property autosummary template
- render property docstrings and examples on discoverable API pages without duplicate object indexing

## Validation
- pre-commit hooks for all changed files
- clean Sphinx HTML build generated property pages; verified pymovements.DatasetPaths.root includes its example and plain fields do not receive pages
- the clean strict build completed generation with 203 unrelated notebook/toctree warnings because notebook execution was disabled

Closes #1702