### PR TITLE
docs: add examples to reading measures and annotations

### DIFF
--- a/src/pymovements/measure/reading/annotation.py
+++ b/src/pymovements/measure/reading/annotation.py
@@ -72,6 +72,28 @@ def run_id(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``run_id`` column.
+
+    Examples
+    --------
+    The id increments on every word change, so the two consecutive fixations on word 1 share a
+    run and the later return to word 0 opens a new one:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import run_id
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, 1, 0, 2]})
+    >>> fixations.with_columns(run_id())
+    shape: (5, 2)
+    ┌──────────┬────────┐
+    │ word_idx ┆ run_id │
+    │ ---      ┆ ---    │
+    │ i64      ┆ i64    │
+    ╞══════════╪════════╡
+    │ 0        ┆ 1      │
+    │ 1        ┆ 2      │
+    │ 1        ┆ 2      │
+    │ 0        ┆ 3      │
+    │ 2        ┆ 4      │
+    └──────────┴────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return (
@@ -100,6 +122,25 @@ def prev_word_idx(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``prev_word_idx`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import prev_word_idx
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, 1, 0, 2]})
+    >>> fixations.with_columns(prev_word_idx())
+    shape: (5, 2)
+    ┌──────────┬───────────────┐
+    │ word_idx ┆ prev_word_idx │
+    │ ---      ┆ ---           │
+    │ i64      ┆ i64           │
+    ╞══════════╪═══════════════╡
+    │ 0        ┆ null          │
+    │ 1        ┆ 0             │
+    │ 1        ┆ 1             │
+    │ 0        ┆ 1             │
+    │ 2        ┆ 0             │
+    └──────────┴───────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.shift().alias('prev_word_idx')
@@ -122,6 +163,25 @@ def next_word_idx(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``next_word_idx`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import next_word_idx
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, 1, 0, 2]})
+    >>> fixations.with_columns(next_word_idx())
+    shape: (5, 2)
+    ┌──────────┬───────────────┐
+    │ word_idx ┆ next_word_idx │
+    │ ---      ┆ ---           │
+    │ i64      ┆ i64           │
+    ╞══════════╪═══════════════╡
+    │ 0        ┆ 1             │
+    │ 1        ┆ 1             │
+    │ 1        ┆ 0             │
+    │ 0        ┆ 2             │
+    │ 2        ┆ null          │
+    └──────────┴───────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.shift(-1).alias('next_word_idx')
@@ -148,6 +208,28 @@ def delta_in(
     -------
     pl.Expr
         Expression producing the ``delta_in`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import delta_in
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'prev_word_idx': [None, 0, 1, 1, 0],
+    ... })
+    >>> fixations.with_columns(delta_in())
+    shape: (5, 3)
+    ┌──────────┬───────────────┬──────────┐
+    │ word_idx ┆ prev_word_idx ┆ delta_in │
+    │ ---      ┆ ---           ┆ ---      │
+    │ i64      ┆ i64           ┆ i64      │
+    ╞══════════╪═══════════════╪══════════╡
+    │ 0        ┆ null          ┆ null     │
+    │ 1        ┆ 0             ┆ 1        │
+    │ 1        ┆ 1             ┆ 0        │
+    │ 0        ┆ 1             ┆ -1       │
+    │ 2        ┆ 0             ┆ 2        │
+    └──────────┴───────────────┴──────────┘
     """
     word_idx_expr = as_expr(word_idx)
     prev_word_idx_expr = as_expr(prev_word_idx)
@@ -175,6 +257,28 @@ def delta_out(
     -------
     pl.Expr
         Expression producing the ``delta_out`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import delta_out
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'next_word_idx': [1, 1, 0, 2, None],
+    ... })
+    >>> fixations.with_columns(delta_out())
+    shape: (5, 3)
+    ┌──────────┬───────────────┬───────────┐
+    │ word_idx ┆ next_word_idx ┆ delta_out │
+    │ ---      ┆ ---           ┆ ---       │
+    │ i64      ┆ i64           ┆ i64       │
+    ╞══════════╪═══════════════╪═══════════╡
+    │ 0        ┆ 1             ┆ 1         │
+    │ 1        ┆ 1             ┆ 0         │
+    │ 1        ┆ 0             ┆ -1        │
+    │ 0        ┆ 2             ┆ 2         │
+    │ 2        ┆ null          ┆ null      │
+    └──────────┴───────────────┴───────────┘
     """
     word_idx_expr = as_expr(word_idx)
     next_word_idx_expr = as_expr(next_word_idx)
@@ -196,6 +300,27 @@ def is_reg_in(delta_in: str | pl.Expr = 'delta_in') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``is_reg_in`` column.
+
+    Examples
+    --------
+    The first fixation has no predecessor, so its ``delta_in`` (and thus ``is_reg_in``) is null:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import is_reg_in
+    >>> fixations = pl.DataFrame({'delta_in': [None, 1, 0, -1, 2]})
+    >>> fixations.with_columns(is_reg_in())
+    shape: (5, 2)
+    ┌──────────┬───────────┐
+    │ delta_in ┆ is_reg_in │
+    │ ---      ┆ ---       │
+    │ i64      ┆ bool      │
+    ╞══════════╪═══════════╡
+    │ null     ┆ null      │
+    │ 1        ┆ false     │
+    │ 0        ┆ false     │
+    │ -1       ┆ true      │
+    │ 2        ┆ false     │
+    └──────────┴───────────┘
     """
     delta_in_expr = as_expr(delta_in)
     return (delta_in_expr < 0).alias('is_reg_in')
@@ -216,6 +341,27 @@ def is_reg_out(delta_out: str | pl.Expr = 'delta_out') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``is_reg_out`` column.
+
+    Examples
+    --------
+    The last fixation has no successor, so its ``delta_out`` (and thus ``is_reg_out``) is null:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import is_reg_out
+    >>> fixations = pl.DataFrame({'delta_out': [1, 0, -1, 2, None]})
+    >>> fixations.with_columns(is_reg_out())
+    shape: (5, 2)
+    ┌───────────┬────────────┐
+    │ delta_out ┆ is_reg_out │
+    │ ---       ┆ ---        │
+    │ i64       ┆ bool       │
+    ╞═══════════╪════════════╡
+    │ 1         ┆ false      │
+    │ 0         ┆ false      │
+    │ -1        ┆ true       │
+    │ 2         ┆ false      │
+    │ null      ┆ null       │
+    └───────────┴────────────┘
     """
     delta_out_expr = as_expr(delta_out)
     return (delta_out_expr < 0).alias('is_reg_out')
@@ -239,6 +385,28 @@ def is_first_fixation(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``is_first_fix`` column.
+
+    Examples
+    --------
+    Apply ``.over('word_idx')`` (or ``.over(group_columns + ['word_idx'])``) so the flag marks the
+    first fixation of each word rather than only the first row overall:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import is_first_fixation
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, 1, 0, 2]})
+    >>> fixations.with_columns(is_first_fixation().over('word_idx'))
+    shape: (5, 2)
+    ┌──────────┬──────────────┐
+    │ word_idx ┆ is_first_fix │
+    │ ---      ┆ ---          │
+    │ i64      ┆ bool         │
+    ╞══════════╪══════════════╡
+    │ 0        ┆ true         │
+    │ 1        ┆ true         │
+    │ 1        ┆ false        │
+    │ 0        ┆ false        │
+    │ 2        ┆ true         │
+    └──────────┴──────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.cum_count().eq(1).alias('is_first_fix')
@@ -279,6 +447,34 @@ def is_first_pass(
     -------
     pl.Expr
         Expression producing the ``is_first_pass`` column.
+
+    Examples
+    --------
+    Refixating the rightmost word read so far stays first-pass (the two ``word_idx == 2`` rows
+    sharing run 3), while returning to it after a word further right has been read does not (the
+    last row, run 5). The input must already carry ``run_id`` (see :func:`run_id`) and be
+    onset-sorted:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import is_first_pass
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 2, 2, 3, 2],
+    ...     'run_id':   [1, 2, 3, 3, 4, 5],
+    ... })
+    >>> fixations.with_columns(is_first_pass())
+    shape: (6, 3)
+    ┌──────────┬────────┬───────────────┐
+    │ word_idx ┆ run_id ┆ is_first_pass │
+    │ ---      ┆ ---    ┆ ---           │
+    │ i64      ┆ i64    ┆ bool          │
+    ╞══════════╪════════╪═══════════════╡
+    │ 0        ┆ 1      ┆ true          │
+    │ 1        ┆ 2      ┆ true          │
+    │ 2        ┆ 3      ┆ true          │
+    │ 2        ┆ 3      ┆ true          │
+    │ 3        ┆ 4      ┆ true          │
+    │ 2        ┆ 5      ┆ false         │
+    └──────────┴────────┴───────────────┘
     """
     group_columns = list(group_columns or [])
     word_idx_expr = as_expr(word_idx)
@@ -319,6 +515,28 @@ def regression_path_word(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     -------
     pl.Expr
         Expression producing the ``regression_path_word`` column.
+
+    Examples
+    --------
+    Every fixation is attributed to the current running maximum of fixated word indices, so the
+    regression to word 0 still belongs to word 1's regression path:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import regression_path_word
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, 1, 0, 2]})
+    >>> fixations.with_columns(regression_path_word())
+    shape: (5, 2)
+    ┌──────────┬──────────────────────┐
+    │ word_idx ┆ regression_path_word │
+    │ ---      ┆ ---                  │
+    │ i64      ┆ i64                  │
+    ╞══════════╪══════════════════════╡
+    │ 0        ┆ 0                    │
+    │ 1        ┆ 1                    │
+    │ 1        ┆ 1                    │
+    │ 0        ┆ 1                    │
+    │ 2        ┆ 2                    │
+    └──────────┴──────────────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.cum_max().alias('regression_path_word')

--- a/src/pymovements/measure/reading/annotation.py
+++ b/src/pymovements/measure/reading/annotation.py
@@ -94,6 +94,26 @@ def run_id(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     │ 0        ┆ 3      │
     │ 2        ┆ 4      │
     └──────────┴────────┘
+
+    Partitioned with ``.over(...)``, the numbering restarts for each reading sequence:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 1, 0, 0],
+    ... })
+    >>> fixations.with_columns(run_id().over('trial'))
+    shape: (5, 3)
+    ┌───────┬──────────┬────────┐
+    │ trial ┆ word_idx ┆ run_id │
+    │ ---   ┆ ---      ┆ ---    │
+    │ i64   ┆ i64      ┆ i64    │
+    ╞═══════╪══════════╪════════╡
+    │ 1     ┆ 0        ┆ 1      │
+    │ 1     ┆ 1        ┆ 2      │
+    │ 1     ┆ 1        ┆ 2      │
+    │ 2     ┆ 0        ┆ 1      │
+    │ 2     ┆ 0        ┆ 1      │
+    └───────┴──────────┴────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return (
@@ -141,6 +161,26 @@ def prev_word_idx(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     │ 0        ┆ 1             │
     │ 2        ┆ 0             │
     └──────────┴───────────────┘
+
+    Partitioned with ``.over(...)``, each reading sequence starts fresh with a null:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 1, 0, 1],
+    ... })
+    >>> fixations.with_columns(prev_word_idx().over('trial'))
+    shape: (5, 3)
+    ┌───────┬──────────┬───────────────┐
+    │ trial ┆ word_idx ┆ prev_word_idx │
+    │ ---   ┆ ---      ┆ ---           │
+    │ i64   ┆ i64      ┆ i64           │
+    ╞═══════╪══════════╪═══════════════╡
+    │ 1     ┆ 0        ┆ null          │
+    │ 1     ┆ 1        ┆ 0             │
+    │ 1     ┆ 1        ┆ 1             │
+    │ 2     ┆ 0        ┆ null          │
+    │ 2     ┆ 1        ┆ 0             │
+    └───────┴──────────┴───────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.shift().alias('prev_word_idx')
@@ -182,6 +222,26 @@ def next_word_idx(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     │ 0        ┆ 2             │
     │ 2        ┆ null          │
     └──────────┴───────────────┘
+
+    Partitioned with ``.over(...)``, each reading sequence ends with a null:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 1, 0, 1],
+    ... })
+    >>> fixations.with_columns(next_word_idx().over('trial'))
+    shape: (5, 3)
+    ┌───────┬──────────┬───────────────┐
+    │ trial ┆ word_idx ┆ next_word_idx │
+    │ ---   ┆ ---      ┆ ---           │
+    │ i64   ┆ i64      ┆ i64           │
+    ╞═══════╪══════════╪═══════════════╡
+    │ 1     ┆ 0        ┆ 1             │
+    │ 1     ┆ 1        ┆ 1             │
+    │ 1     ┆ 1        ┆ null          │
+    │ 2     ┆ 0        ┆ 1             │
+    │ 2     ┆ 1        ┆ null          │
+    └───────┴──────────┴───────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.shift(-1).alias('next_word_idx')
@@ -230,6 +290,29 @@ def delta_in(
     │ 0        ┆ 1             ┆ -1       │
     │ 2        ┆ 0             ┆ 2        │
     └──────────┴───────────────┴──────────┘
+
+    The previous word index need not be materialized as a column: any expression works, e.g.
+    composing the :func:`prev_word_idx` factory directly. The composed expression then contains
+    a window and needs ``.over(...)`` to partition into reading sequences:
+
+    >>> from pymovements.measure.reading import prev_word_idx
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ... })
+    >>> fixations.with_columns(delta_in(prev_word_idx=prev_word_idx()).over('trial'))
+    shape: (5, 3)
+    ┌───────┬──────────┬──────────┐
+    │ trial ┆ word_idx ┆ delta_in │
+    │ ---   ┆ ---      ┆ ---      │
+    │ i64   ┆ i64      ┆ i64      │
+    ╞═══════╪══════════╪══════════╡
+    │ 1     ┆ 0        ┆ null     │
+    │ 1     ┆ 1        ┆ 1        │
+    │ 1     ┆ 0        ┆ -1       │
+    │ 2     ┆ 0        ┆ null     │
+    │ 2     ┆ 1        ┆ 1        │
+    └───────┴──────────┴──────────┘
     """
     word_idx_expr = as_expr(word_idx)
     prev_word_idx_expr = as_expr(prev_word_idx)
@@ -279,6 +362,29 @@ def delta_out(
     │ 0        ┆ 2             ┆ 2         │
     │ 2        ┆ null          ┆ null      │
     └──────────┴───────────────┴───────────┘
+
+    The next word index need not be materialized as a column: any expression works, e.g.
+    composing the :func:`next_word_idx` factory directly. The composed expression then contains
+    a window and needs ``.over(...)`` to partition into reading sequences:
+
+    >>> from pymovements.measure.reading import next_word_idx
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ... })
+    >>> fixations.with_columns(delta_out(next_word_idx=next_word_idx()).over('trial'))
+    shape: (5, 3)
+    ┌───────┬──────────┬───────────┐
+    │ trial ┆ word_idx ┆ delta_out │
+    │ ---   ┆ ---      ┆ ---       │
+    │ i64   ┆ i64      ┆ i64       │
+    ╞═══════╪══════════╪═══════════╡
+    │ 1     ┆ 0        ┆ 1         │
+    │ 1     ┆ 1        ┆ -1        │
+    │ 1     ┆ 0        ┆ null      │
+    │ 2     ┆ 0        ┆ 1         │
+    │ 2     ┆ 1        ┆ null      │
+    └───────┴──────────┴───────────┘
     """
     word_idx_expr = as_expr(word_idx)
     next_word_idx_expr = as_expr(next_word_idx)
@@ -321,6 +427,31 @@ def is_reg_in(delta_in: str | pl.Expr = 'delta_in') -> pl.Expr:
     │ -1       ┆ true      │
     │ 2        ┆ false     │
     └──────────┴───────────┘
+
+    Composing the :func:`delta_in` and :func:`prev_word_idx` factories computes the flag straight
+    from the word indices; the composed expression then contains a window and needs ``.over(...)``
+    to partition into reading sequences:
+
+    >>> from pymovements.measure.reading import delta_in, prev_word_idx
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ... })
+    >>> fixations.with_columns(
+    ...     is_reg_in(delta_in(prev_word_idx=prev_word_idx())).over('trial'),
+    ... )
+    shape: (5, 3)
+    ┌───────┬──────────┬───────────┐
+    │ trial ┆ word_idx ┆ is_reg_in │
+    │ ---   ┆ ---      ┆ ---       │
+    │ i64   ┆ i64      ┆ bool      │
+    ╞═══════╪══════════╪═══════════╡
+    │ 1     ┆ 0        ┆ null      │
+    │ 1     ┆ 1        ┆ false     │
+    │ 1     ┆ 0        ┆ true      │
+    │ 2     ┆ 0        ┆ null      │
+    │ 2     ┆ 1        ┆ false     │
+    └───────┴──────────┴───────────┘
     """
     delta_in_expr = as_expr(delta_in)
     return (delta_in_expr < 0).alias('is_reg_in')
@@ -362,6 +493,31 @@ def is_reg_out(delta_out: str | pl.Expr = 'delta_out') -> pl.Expr:
     │ 2         ┆ false      │
     │ null      ┆ null       │
     └───────────┴────────────┘
+
+    Composing the :func:`delta_out` and :func:`next_word_idx` factories computes the flag straight
+    from the word indices; the composed expression then contains a window and needs ``.over(...)``
+    to partition into reading sequences:
+
+    >>> from pymovements.measure.reading import delta_out, next_word_idx
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ... })
+    >>> fixations.with_columns(
+    ...     is_reg_out(delta_out(next_word_idx=next_word_idx())).over('trial'),
+    ... )
+    shape: (5, 3)
+    ┌───────┬──────────┬────────────┐
+    │ trial ┆ word_idx ┆ is_reg_out │
+    │ ---   ┆ ---      ┆ ---        │
+    │ i64   ┆ i64      ┆ bool       │
+    ╞═══════╪══════════╪════════════╡
+    │ 1     ┆ 0        ┆ false      │
+    │ 1     ┆ 1        ┆ true       │
+    │ 1     ┆ 0        ┆ null       │
+    │ 2     ┆ 0        ┆ false      │
+    │ 2     ┆ 1        ┆ null       │
+    └───────┴──────────┴────────────┘
     """
     delta_out_expr = as_expr(delta_out)
     return (delta_out_expr < 0).alias('is_reg_out')
@@ -407,6 +563,27 @@ def is_first_fixation(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     │ 0        ┆ false        │
     │ 2        ┆ true         │
     └──────────┴──────────────┘
+
+    With group columns in the window, refixations only count within their own sequence, so the
+    same word is flagged again in a new trial:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 0, 1, 0, 0],
+    ... })
+    >>> fixations.with_columns(is_first_fixation().over(['trial', 'word_idx']))
+    shape: (5, 3)
+    ┌───────┬──────────┬──────────────┐
+    │ trial ┆ word_idx ┆ is_first_fix │
+    │ ---   ┆ ---      ┆ ---          │
+    │ i64   ┆ i64      ┆ bool         │
+    ╞═══════╪══════════╪══════════════╡
+    │ 1     ┆ 0        ┆ true         │
+    │ 1     ┆ 0        ┆ false        │
+    │ 1     ┆ 1        ┆ true         │
+    │ 2     ┆ 0        ┆ true         │
+    │ 2     ┆ 0        ┆ false        │
+    └───────┴──────────┴──────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.cum_count().eq(1).alias('is_first_fix')
@@ -475,6 +652,28 @@ def is_first_pass(
     │ 3        ┆ 4      ┆ true          │
     │ 2        ┆ 5      ┆ false         │
     └──────────┴────────┴───────────────┘
+
+    With ``group_columns``, each sequence is evaluated independently, so the regressed-to word 0
+    of trial 1 is first-pass again in trial 2:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial':    [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ...     'run_id':   [1, 2, 3, 1, 2],
+    ... })
+    >>> fixations.with_columns(is_first_pass(group_columns=['trial']))
+    shape: (5, 4)
+    ┌───────┬──────────┬────────┬───────────────┐
+    │ trial ┆ word_idx ┆ run_id ┆ is_first_pass │
+    │ ---   ┆ ---      ┆ ---    ┆ ---           │
+    │ i64   ┆ i64      ┆ i64    ┆ bool          │
+    ╞═══════╪══════════╪════════╪═══════════════╡
+    │ 1     ┆ 0        ┆ 1      ┆ true          │
+    │ 1     ┆ 1        ┆ 2      ┆ true          │
+    │ 1     ┆ 0        ┆ 3      ┆ false         │
+    │ 2     ┆ 0        ┆ 1      ┆ true          │
+    │ 2     ┆ 1        ┆ 2      ┆ true          │
+    └───────┴──────────┴────────┴───────────────┘
     """
     group_columns = list(group_columns or [])
     word_idx_expr = as_expr(word_idx)
@@ -537,6 +736,26 @@ def regression_path_word(word_idx: str | pl.Expr = 'word_idx') -> pl.Expr:
     │ 0        ┆ 1                    │
     │ 2        ┆ 2                    │
     └──────────┴──────────────────────┘
+
+    Partitioned with ``.over(...)``, the running maximum restarts for each reading sequence:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2, 0],
+    ... })
+    >>> fixations.with_columns(regression_path_word().over('trial'))
+    shape: (5, 3)
+    ┌───────┬──────────┬──────────────────────┐
+    │ trial ┆ word_idx ┆ regression_path_word │
+    │ ---   ┆ ---      ┆ ---                  │
+    │ i64   ┆ i64      ┆ i64                  │
+    ╞═══════╪══════════╪══════════════════════╡
+    │ 1     ┆ 0        ┆ 0                    │
+    │ 1     ┆ 1        ┆ 1                    │
+    │ 1     ┆ 0        ┆ 1                    │
+    │ 2     ┆ 2        ┆ 2                    │
+    │ 2     ┆ 0        ┆ 2                    │
+    └───────┴──────────┴──────────────────────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.cum_max().alias('regression_path_word')
@@ -615,6 +834,30 @@ def annotate_fixations(
     │ 0        ┆ 3      ┆ false         ┆ 1                    │
     │ 2        ┆ 4      ┆ true          ┆ 2                    │
     └──────────┴────────┴───────────────┴──────────────────────┘
+
+    With ``group_columns``, each trial is annotated independently: run IDs restart, and word 1
+    of trial 2 counts as first-pass even though trial 1 already fixated it. Within trial 2 the
+    later fixation on word 0 arrives from the right and is thus not first-pass:
+
+    >>> fixations = pl.DataFrame({
+    ...     'name': ['fixation'] * 4,
+    ...     'onset': [0, 250, 0, 250],
+    ...     'word_idx': [0, 1, 1, 0],
+    ...     'trial': [1, 1, 2, 2],
+    ... })
+    >>> annotated = annotate_fixations(fixations, group_columns=['trial'])
+    >>> annotated.select('trial', 'word_idx', 'run_id', 'is_first_pass')
+    shape: (4, 4)
+    ┌───────┬──────────┬────────┬───────────────┐
+    │ trial ┆ word_idx ┆ run_id ┆ is_first_pass │
+    │ ---   ┆ ---      ┆ ---    ┆ ---           │
+    │ i64   ┆ i64      ┆ i64    ┆ bool          │
+    ╞═══════╪══════════╪════════╪═══════════════╡
+    │ 1     ┆ 0        ┆ 1      ┆ true          │
+    │ 1     ┆ 1        ┆ 2      ┆ true          │
+    │ 2     ┆ 1        ┆ 1      ┆ true          │
+    │ 2     ┆ 0        ┆ 2      ┆ false         │
+    └───────┴──────────┴────────┴───────────────┘
     """
     group_columns = list(group_columns or [])
     word_idx_expr = as_expr(word_idx)

--- a/src/pymovements/measure/reading/annotation.py
+++ b/src/pymovements/measure/reading/annotation.py
@@ -253,7 +253,8 @@ def delta_in(
 ) -> pl.Expr:
     """Compute the difference in word index from the previous fixation.
 
-    Row-wise, no window needed.
+    Row-wise on materialized input columns, so no window is needed then. A window-dependent
+    input expression such as :func:`prev_word_idx` reintroduces the need for ``.over(...)``.
 
     Parameters
     ----------
@@ -325,7 +326,8 @@ def delta_out(
 ) -> pl.Expr:
     """Compute the difference in word index to the next fixation.
 
-    Row-wise, no window needed.
+    Row-wise on materialized input columns, so no window is needed then. A window-dependent
+    input expression such as :func:`next_word_idx` reintroduces the need for ``.over(...)``.
 
     Parameters
     ----------
@@ -394,7 +396,9 @@ def delta_out(
 def is_reg_in(delta_in: str | pl.Expr = 'delta_in') -> pl.Expr:
     """Flag fixations that arrive from a higher-index word (regression in).
 
-    Row-wise, no window needed.
+    Row-wise on materialized input columns, so no window is needed then. A window-dependent
+    input expression such as a composed :func:`delta_in` reintroduces the need for
+    ``.over(...)``.
 
     Parameters
     ----------
@@ -460,7 +464,9 @@ def is_reg_in(delta_in: str | pl.Expr = 'delta_in') -> pl.Expr:
 def is_reg_out(delta_out: str | pl.Expr = 'delta_out') -> pl.Expr:
     """Flag fixations that depart to a lower-index word (regression out).
 
-    Row-wise, no window needed.
+    Row-wise on materialized input columns, so no window is needed then. A window-dependent
+    input expression such as a composed :func:`delta_out` reintroduces the need for
+    ``.over(...)``.
 
     Parameters
     ----------

--- a/src/pymovements/measure/reading/measures.py
+++ b/src/pymovements/measure/reading/measures.py
@@ -80,6 +80,26 @@ def total_fixation_count() -> pl.Expr:
     │ 1        ┆ 2   │
     │ 2        ┆ 1   │
     └──────────┴─────┘
+
+    Grouping by trial and word keeps the counts per reading sequence:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2, 2],
+    ...     'word_idx': [0, 0, 0, 1, 1],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     total_fixation_count(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (3, 3)
+    ┌───────┬──────────┬─────┐
+    │ trial ┆ word_idx ┆ TFC │
+    │ ---   ┆ ---      ┆ --- │
+    │ i64   ┆ i64      ┆ u64 │
+    ╞═══════╪══════════╪═════╡
+    │ 1     ┆ 0        ┆ 2   │
+    │ 2     ┆ 0        ┆ 1   │
+    │ 2     ┆ 1        ┆ 2   │
+    └───────┴──────────┴─────┘
     """
     return pl.len().cast(pl.UInt64).alias('TFC')
 
@@ -117,6 +137,30 @@ def first_pass_fixation_count(is_first_pass: str | pl.Expr = 'is_first_pass') ->
     │ 1        ┆ 2    │
     │ 2        ┆ 1    │
     └──────────┴──────┘
+
+    Grouping by trial and word keeps the counts per reading sequence. In trial 2, word 1 was
+    skipped and only entered by a regression, so it has no first-pass fixations:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2, 1],
+    ...     'is_first_pass': [True, True, True, True, False],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     first_pass_fixation_count(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (5, 3)
+    ┌───────┬──────────┬──────┐
+    │ trial ┆ word_idx ┆ FPFC │
+    │ ---   ┆ ---      ┆ ---  │
+    │ i64   ┆ i64      ┆ u64  │
+    ╞═══════╪══════════╪══════╡
+    │ 1     ┆ 0        ┆ 1    │
+    │ 1     ┆ 1        ┆ 1    │
+    │ 2     ┆ 0        ┆ 1    │
+    │ 2     ┆ 1        ┆ 0    │
+    │ 2     ┆ 2        ┆ 1    │
+    └───────┴──────────┴──────┘
     """
     is_first_pass_expr = as_expr(is_first_pass)
     return is_first_pass_expr.sum().cast(pl.UInt64).alias('FPFC')
@@ -157,6 +201,27 @@ def first_duration(duration: str | pl.Expr = 'duration') -> pl.Expr:
     │ 1        ┆ 200 │
     │ 2        ┆ 130 │
     └──────────┴─────┘
+
+    Grouping by trial and word yields a first fixation per reading sequence, so the same word
+    gets a fresh FD in every trial:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2],
+    ...     'word_idx': [0, 0, 0],
+    ...     'duration': [100, 120, 90],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     first_duration(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (2, 3)
+    ┌───────┬──────────┬─────┐
+    │ trial ┆ word_idx ┆ FD  │
+    │ ---   ┆ ---      ┆ --- │
+    │ i64   ┆ i64      ┆ i64 │
+    ╞═══════╪══════════╪═════╡
+    │ 1     ┆ 0        ┆ 100 │
+    │ 2     ┆ 0        ┆ 90  │
+    └───────┴──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     return duration_expr.first().alias('FD')
@@ -208,6 +273,30 @@ def first_reading_time(
     │ 1        ┆ 350 │
     │ 2        ┆ 130 │
     └──────────┴─────┘
+
+    Grouping by trial and word evaluates the first run per reading sequence; the run IDs restart
+    with each trial when :func:`~pymovements.measure.reading.run_id` is applied with
+    ``.over('trial')``:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 0, 1, 0, 0],
+    ...     'duration': [100, 150, 200, 120, 130],
+    ...     'run_id': [1, 1, 2, 1, 1],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     first_reading_time(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (3, 3)
+    ┌───────┬──────────┬─────┐
+    │ trial ┆ word_idx ┆ FRT │
+    │ ---   ┆ ---      ┆ --- │
+    │ i64   ┆ i64      ┆ i64 │
+    ╞═══════╪══════════╪═════╡
+    │ 1     ┆ 0        ┆ 250 │
+    │ 1     ┆ 1        ┆ 200 │
+    │ 2     ┆ 0        ┆ 250 │
+    └───────┴──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     run_id_expr = as_expr(run_id)
@@ -261,6 +350,32 @@ def first_fixation_duration(
     │ 1        ┆ 200 │
     │ 2        ┆ 130 │
     └──────────┴─────┘
+
+    Grouping by trial and word evaluates each reading sequence on its own. In trial 2, word 1 was
+    skipped and only entered by a regression, so it has no first-pass fixation at all and its FFD
+    is null (unlike its FD, see :func:`first_duration`):
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2, 1],
+    ...     'duration': [100, 200, 150, 180, 120],
+    ...     'is_first_pass': [True, True, True, True, False],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     first_fixation_duration(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (5, 3)
+    ┌───────┬──────────┬──────┐
+    │ trial ┆ word_idx ┆ FFD  │
+    │ ---   ┆ ---      ┆ ---  │
+    │ i64   ┆ i64      ┆ i64  │
+    ╞═══════╪══════════╪══════╡
+    │ 1     ┆ 0        ┆ 100  │
+    │ 1     ┆ 1        ┆ 200  │
+    │ 2     ┆ 0        ┆ 150  │
+    │ 2     ┆ 1        ┆ null │
+    │ 2     ┆ 2        ┆ 180  │
+    └───────┴──────────┴──────┘
     """
     duration_expr = as_expr(duration)
     is_first_pass_expr = as_expr(is_first_pass)
@@ -307,6 +422,32 @@ def first_pass_reading_time(
     │ 1        ┆ 350  │
     │ 2        ┆ 130  │
     └──────────┴──────┘
+
+    Grouping by trial and word evaluates each reading sequence on its own. In trial 2, word 1 was
+    skipped and only entered by a regression, so no first-pass time accumulates and the sum over
+    the empty selection is 0 (while its FFD is null, see :func:`first_fixation_duration`):
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2, 1],
+    ...     'duration': [100, 200, 150, 180, 120],
+    ...     'is_first_pass': [True, True, True, True, False],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     first_pass_reading_time(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (5, 3)
+    ┌───────┬──────────┬──────┐
+    │ trial ┆ word_idx ┆ FPRT │
+    │ ---   ┆ ---      ┆ ---  │
+    │ i64   ┆ i64      ┆ i64  │
+    ╞═══════╪══════════╪══════╡
+    │ 1     ┆ 0        ┆ 100  │
+    │ 1     ┆ 1        ┆ 200  │
+    │ 2     ┆ 0        ┆ 150  │
+    │ 2     ┆ 1        ┆ 0    │
+    │ 2     ┆ 2        ┆ 180  │
+    └───────┴──────────┴──────┘
     """
     duration_expr = as_expr(duration)
     is_first_pass_expr = as_expr(is_first_pass)
@@ -356,6 +497,31 @@ def rereading_time(
     │ 1        ┆ 0   │
     │ 2        ┆ 0   │
     └──────────┴─────┘
+
+    Grouping by trial and word evaluates each reading sequence on its own. In trial 2, word 1 was
+    only entered by a regression, so its whole fixation time counts as rereading:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2, 1],
+    ...     'duration': [100, 200, 150, 180, 120],
+    ...     'is_first_pass': [True, True, True, True, False],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     rereading_time(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (5, 3)
+    ┌───────┬──────────┬─────┐
+    │ trial ┆ word_idx ┆ RRT │
+    │ ---   ┆ ---      ┆ --- │
+    │ i64   ┆ i64      ┆ i64 │
+    ╞═══════╪══════════╪═════╡
+    │ 1     ┆ 0        ┆ 0   │
+    │ 1     ┆ 1        ┆ 0   │
+    │ 2     ┆ 0        ┆ 0   │
+    │ 2     ┆ 1        ┆ 120 │
+    │ 2     ┆ 2        ┆ 0   │
+    └───────┴──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     is_first_pass_expr = as_expr(is_first_pass)
@@ -400,6 +566,29 @@ def regression_count_in(is_reg_in: str | pl.Expr = 'is_reg_in') -> pl.Expr:
     │ 1        ┆ 0      │
     │ 2        ┆ 0      │
     └──────────┴────────┘
+
+    Grouping by trial and word keeps the counts per reading sequence, so the regression into
+    word 0 of trial 1 does not leak into trial 2:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ...     'is_reg_in': [None, False, True, None, False],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     regression_count_in(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (4, 3)
+    ┌───────┬──────────┬────────┐
+    │ trial ┆ word_idx ┆ TRC_in │
+    │ ---   ┆ ---      ┆ ---    │
+    │ i64   ┆ i64      ┆ u64    │
+    ╞═══════╪══════════╪════════╡
+    │ 1     ┆ 0        ┆ 1      │
+    │ 1     ┆ 1        ┆ 0      │
+    │ 2     ┆ 0        ┆ 0      │
+    │ 2     ┆ 1        ┆ 0      │
+    └───────┴──────────┴────────┘
     """
     is_reg_in_expr = as_expr(is_reg_in)
     return is_reg_in_expr.sum().cast(pl.UInt64).alias('TRC_in')
@@ -438,6 +627,29 @@ def regression_count_out(is_reg_out: str | pl.Expr = 'is_reg_out') -> pl.Expr:
     │ 1        ┆ 1       │
     │ 2        ┆ 0       │
     └──────────┴─────────┘
+
+    Grouping by trial and word keeps the counts per reading sequence, so the regression out of
+    word 1 of trial 1 does not leak into trial 2:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ...     'is_reg_out': [False, True, None, False, None],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     regression_count_out(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (4, 3)
+    ┌───────┬──────────┬─────────┐
+    │ trial ┆ word_idx ┆ TRC_out │
+    │ ---   ┆ ---      ┆ ---     │
+    │ i64   ┆ i64      ┆ u64     │
+    ╞═══════╪══════════╪═════════╡
+    │ 1     ┆ 0        ┆ 0       │
+    │ 1     ┆ 1        ┆ 1       │
+    │ 2     ┆ 0        ┆ 0       │
+    │ 2     ┆ 1        ┆ 0       │
+    └───────┴──────────┴─────────┘
     """
     is_reg_out_expr = as_expr(is_reg_out)
     return is_reg_out_expr.sum().cast(pl.UInt64).alias('TRC_out')
@@ -489,6 +701,28 @@ def landing_position(char_idx: str | pl.Expr = 'char_idx') -> pl.Expr:
     │ 1        ┆ 5   │
     │ 2        ┆ 9   │
     └──────────┴─────┘
+
+    Grouping by trial and word evaluates the first fixation per reading sequence, so the same
+    word gets a fresh landing position in every trial:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2],
+    ...     'word_idx': [0, 1, 0],
+    ...     'char_idx': [0, 4, 2],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     landing_position(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (3, 3)
+    ┌───────┬──────────┬─────┐
+    │ trial ┆ word_idx ┆ LP  │
+    │ ---   ┆ ---      ┆ --- │
+    │ i64   ┆ i64      ┆ i64 │
+    ╞═══════╪══════════╪═════╡
+    │ 1     ┆ 0        ┆ 1   │
+    │ 1     ┆ 1        ┆ 5   │
+    │ 2     ┆ 0        ┆ 3   │
+    └───────┴──────────┴─────┘
     """
     char_idx_expr = as_expr(char_idx)
     return (char_idx_expr.first() + 1).alias('LP')
@@ -545,6 +779,30 @@ def saccade_length_in(
     │ 1        ┆ 1     │
     │ 2        ┆ 2     │
     └──────────┴───────┘
+
+    Grouping by trial and word evaluates each reading sequence on its own, so the first word of
+    every trial has a null entry saccade:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2],
+    ...     'prev_word_idx': [None, 0, None, 0],
+    ...     'is_first_fix': [True, True, True, True],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     saccade_length_in(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (4, 3)
+    ┌───────┬──────────┬───────┐
+    │ trial ┆ word_idx ┆ SL_in │
+    │ ---   ┆ ---      ┆ ---   │
+    │ i64   ┆ i64      ┆ i64   │
+    ╞═══════╪══════════╪═══════╡
+    │ 1     ┆ 0        ┆ null  │
+    │ 1     ┆ 1        ┆ 1     │
+    │ 2     ┆ 0        ┆ null  │
+    │ 2     ┆ 2        ┆ 2     │
+    └───────┴──────────┴───────┘
     """
     word_idx_expr = as_expr(word_idx)
     prev_word_idx_expr = as_expr(prev_word_idx)
@@ -608,6 +866,30 @@ def saccade_length_out(
     │ 1        ┆ -1     │
     │ 2        ┆ 0      │
     └──────────┴────────┘
+
+    Grouping by trial and word evaluates each reading sequence on its own, so the last word of
+    every trial gets a 0 exit saccade:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2],
+    ...     'word_idx': [0, 1, 0, 2],
+    ...     'next_word_idx': [1, None, 2, None],
+    ...     'run_id': [1, 2, 1, 2],
+    ... })
+    >>> fixations.group_by(['trial', 'word_idx']).agg(
+    ...     saccade_length_out(),
+    ... ).sort(['trial', 'word_idx'])
+    shape: (4, 3)
+    ┌───────┬──────────┬────────┐
+    │ trial ┆ word_idx ┆ SL_out │
+    │ ---   ┆ ---      ┆ ---    │
+    │ i64   ┆ i64      ┆ i64    │
+    ╞═══════╪══════════╪════════╡
+    │ 1     ┆ 0        ┆ 1      │
+    │ 1     ┆ 1        ┆ 0      │
+    │ 2     ┆ 0        ┆ 2      │
+    │ 2     ┆ 2        ┆ 0      │
+    └───────┴──────────┴────────┘
     """
     word_idx_expr = as_expr(word_idx)
     next_word_idx_expr = as_expr(next_word_idx)
@@ -669,6 +951,28 @@ def regression_path_duration_inclusive(duration: str | pl.Expr = 'duration') -> 
     │ 1                    ┆ 470     │
     │ 2                    ┆ 130     │
     └──────────────────────┴─────────┘
+
+    Grouping by trial and regression-path word keeps the windows per reading sequence:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'regression_path_word': [0, 1, 1, 0, 1],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by(['trial', 'regression_path_word']).agg(
+    ...     regression_path_duration_inclusive(),
+    ... ).sort(['trial', 'regression_path_word'])
+    shape: (4, 3)
+    ┌───────┬──────────────────────┬─────────┐
+    │ trial ┆ regression_path_word ┆ RPD_inc │
+    │ ---   ┆ ---                  ┆ ---     │
+    │ i64   ┆ i64                  ┆ i64     │
+    ╞═══════╪══════════════════════╪═════════╡
+    │ 1     ┆ 0                    ┆ 100     │
+    │ 1     ┆ 1                    ┆ 350     │
+    │ 2     ┆ 0                    ┆ 120     │
+    │ 2     ┆ 1                    ┆ 130     │
+    └───────┴──────────────────────┴─────────┘
     """
     duration_expr = as_expr(duration)
     return duration_expr.sum().alias('RPD_inc')
@@ -727,6 +1031,30 @@ def regression_path_duration_exclusive(
     │ 1                    ┆ 120     │
     │ 2                    ┆ 0       │
     └──────────────────────┴─────────┘
+
+    Grouping by trial and regression-path word keeps the windows per reading sequence; only
+    trial 1 contains a regression (to word 0, inside word 1's window):
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'regression_path_word': [0, 1, 1, 0, 1],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by(['trial', 'regression_path_word']).agg(
+    ...     regression_path_duration_exclusive(),
+    ... ).sort(['trial', 'regression_path_word'])
+    shape: (4, 3)
+    ┌───────┬──────────────────────┬─────────┐
+    │ trial ┆ regression_path_word ┆ RPD_exc │
+    │ ---   ┆ ---                  ┆ ---     │
+    │ i64   ┆ i64                  ┆ i64     │
+    ╞═══════╪══════════════════════╪═════════╡
+    │ 1     ┆ 0                    ┆ 0       │
+    │ 1     ┆ 1                    ┆ 150     │
+    │ 2     ┆ 0                    ┆ 0       │
+    │ 2     ┆ 1                    ┆ 0       │
+    └───────┴──────────────────────┴─────────┘
     """
     duration_expr = as_expr(duration)
     word_idx_expr = as_expr(word_idx)
@@ -791,6 +1119,30 @@ def right_bounded_reading_time(
     │ 1                    ┆ 350  │
     │ 2                    ┆ 130  │
     └──────────────────────┴──────┘
+
+    Grouping by trial and regression-path word keeps the windows per reading sequence; the
+    regressed time on word 0 of trial 1 is excluded from word 1's RBRT:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 1, 2, 2],
+    ...     'regression_path_word': [0, 1, 1, 0, 1],
+    ...     'word_idx': [0, 1, 0, 0, 1],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by(['trial', 'regression_path_word']).agg(
+    ...     right_bounded_reading_time(),
+    ... ).sort(['trial', 'regression_path_word'])
+    shape: (4, 3)
+    ┌───────┬──────────────────────┬──────┐
+    │ trial ┆ regression_path_word ┆ RBRT │
+    │ ---   ┆ ---                  ┆ ---  │
+    │ i64   ┆ i64                  ┆ i64  │
+    ╞═══════╪══════════════════════╪══════╡
+    │ 1     ┆ 0                    ┆ 100  │
+    │ 1     ┆ 1                    ┆ 200  │
+    │ 2     ┆ 0                    ┆ 120  │
+    │ 2     ┆ 1                    ┆ 130  │
+    └───────┴──────────────────────┴──────┘
     """
     duration_expr = as_expr(duration)
     word_idx_expr = as_expr(word_idx)
@@ -852,6 +1204,23 @@ def non_aoi_fixation_count_ratio(word_idx: str | pl.Expr = 'word_idx') -> pl.Exp
     ╞═══════╡
     │ 0.25  │
     └───────┘
+
+    Grouping by the reading-sequence columns yields one ratio per sequence:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2],
+    ...     'word_idx': [0, None, 1, 2],
+    ... })
+    >>> fixations.group_by('trial').agg(non_aoi_fixation_count_ratio()).sort('trial')
+    shape: (2, 2)
+    ┌───────┬───────┐
+    │ trial ┆ NAFCR │
+    │ ---   ┆ ---   │
+    │ i64   ┆ f64   │
+    ╞═══════╪═══════╡
+    │ 1     ┆ 0.5   │
+    │ 2     ┆ 0.0   │
+    └───────┴───────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.is_null().mean().alias('NAFCR')
@@ -911,6 +1280,24 @@ def non_aoi_fixation_duration_ratio(
     ╞═══════╡
     │ 0.1   │
     └───────┘
+
+    Grouping by the reading-sequence columns yields one ratio per sequence:
+
+    >>> fixations = pl.DataFrame({
+    ...     'trial': [1, 1, 2, 2],
+    ...     'word_idx': [0, None, 1, 2],
+    ...     'duration': [150, 50, 100, 100],
+    ... })
+    >>> fixations.group_by('trial').agg(non_aoi_fixation_duration_ratio()).sort('trial')
+    shape: (2, 2)
+    ┌───────┬───────┐
+    │ trial ┆ NAFDR │
+    │ ---   ┆ ---   │
+    │ i64   ┆ f64   │
+    ╞═══════╪═══════╡
+    │ 1     ┆ 0.25  │
+    │ 2     ┆ 0.0   │
+    └───────┴───────┘
     """
     duration_expr = as_expr(duration)
     word_idx_expr = as_expr(word_idx)

--- a/src/pymovements/measure/reading/measures.py
+++ b/src/pymovements/measure/reading/measures.py
@@ -63,6 +63,23 @@ def total_fixation_count() -> pl.Expr:
     -------
     pl.Expr
         Aggregation expression producing the ``TFC`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import total_fixation_count
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, 1, 0, 2]})
+    >>> fixations.group_by('word_idx').agg(total_fixation_count()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────┐
+    │ word_idx ┆ TFC │
+    │ ---      ┆ --- │
+    │ i64      ┆ u64 │
+    ╞══════════╪═════╡
+    │ 0        ┆ 2   │
+    │ 1        ┆ 2   │
+    │ 2        ┆ 1   │
+    └──────────┴─────┘
     """
     return pl.len().cast(pl.UInt64).alias('TFC')
 
@@ -80,6 +97,26 @@ def first_pass_fixation_count(is_first_pass: str | pl.Expr = 'is_first_pass') ->
     -------
     pl.Expr
         Aggregation expression producing the ``FPFC`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import first_pass_fixation_count
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'is_first_pass': [True, True, True, False, True],
+    ... })
+    >>> fixations.group_by('word_idx').agg(first_pass_fixation_count()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬──────┐
+    │ word_idx ┆ FPFC │
+    │ ---      ┆ ---  │
+    │ i64      ┆ u64  │
+    ╞══════════╪══════╡
+    │ 0        ┆ 1    │
+    │ 1        ┆ 2    │
+    │ 2        ┆ 1    │
+    └──────────┴──────┘
     """
     is_first_pass_expr = as_expr(is_first_pass)
     return is_first_pass_expr.sum().cast(pl.UInt64).alias('FPFC')
@@ -100,6 +137,26 @@ def first_duration(duration: str | pl.Expr = 'duration') -> pl.Expr:
     -------
     pl.Expr
         Aggregation expression producing the ``FD`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import first_duration
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by('word_idx').agg(first_duration()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────┐
+    │ word_idx ┆ FD  │
+    │ ---      ┆ --- │
+    │ i64      ┆ i64 │
+    ╞══════════╪═════╡
+    │ 0        ┆ 100 │
+    │ 1        ┆ 200 │
+    │ 2        ┆ 130 │
+    └──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     return duration_expr.first().alias('FD')
@@ -127,6 +184,30 @@ def first_reading_time(
     -------
     pl.Expr
         Aggregation expression producing the ``FRT`` column.
+
+    Examples
+    --------
+    The two fixations on word 1 share the first run, so their durations are summed; the later
+    return to word 0 is a second run and does not count:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import first_reading_time
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ...     'run_id': [1, 2, 2, 3, 4],
+    ... })
+    >>> fixations.group_by('word_idx').agg(first_reading_time()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────┐
+    │ word_idx ┆ FRT │
+    │ ---      ┆ --- │
+    │ i64      ┆ i64 │
+    ╞══════════╪═════╡
+    │ 0        ┆ 100 │
+    │ 1        ┆ 350 │
+    │ 2        ┆ 130 │
+    └──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     run_id_expr = as_expr(run_id)
@@ -159,6 +240,27 @@ def first_fixation_duration(
     -------
     pl.Expr
         Aggregation expression producing the ``FFD`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import first_fixation_duration
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ...     'is_first_pass': [True, True, True, False, True],
+    ... })
+    >>> fixations.group_by('word_idx').agg(first_fixation_duration()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────┐
+    │ word_idx ┆ FFD │
+    │ ---      ┆ --- │
+    │ i64      ┆ i64 │
+    ╞══════════╪═════╡
+    │ 0        ┆ 100 │
+    │ 1        ┆ 200 │
+    │ 2        ┆ 130 │
+    └──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     is_first_pass_expr = as_expr(is_first_pass)
@@ -184,6 +286,27 @@ def first_pass_reading_time(
     -------
     pl.Expr
         Aggregation expression producing the ``FPRT`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import first_pass_reading_time
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ...     'is_first_pass': [True, True, True, False, True],
+    ... })
+    >>> fixations.group_by('word_idx').agg(first_pass_reading_time()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬──────┐
+    │ word_idx ┆ FPRT │
+    │ ---      ┆ ---  │
+    │ i64      ┆ i64  │
+    ╞══════════╪══════╡
+    │ 0        ┆ 100  │
+    │ 1        ┆ 350  │
+    │ 2        ┆ 130  │
+    └──────────┴──────┘
     """
     duration_expr = as_expr(duration)
     is_first_pass_expr = as_expr(is_first_pass)
@@ -209,6 +332,30 @@ def rereading_time(
     -------
     pl.Expr
         Aggregation expression producing the ``RRT`` column.
+
+    Examples
+    --------
+    Only the regression to word 0 falls outside its first pass, so every other word rereads for
+    zero:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import rereading_time
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ...     'is_first_pass': [True, True, True, False, True],
+    ... })
+    >>> fixations.group_by('word_idx').agg(rereading_time()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────┐
+    │ word_idx ┆ RRT │
+    │ ---      ┆ --- │
+    │ i64      ┆ i64 │
+    ╞══════════╪═════╡
+    │ 0        ┆ 120 │
+    │ 1        ┆ 0   │
+    │ 2        ┆ 0   │
+    └──────────┴─────┘
     """
     duration_expr = as_expr(duration)
     is_first_pass_expr = as_expr(is_first_pass)
@@ -233,6 +380,26 @@ def regression_count_in(is_reg_in: str | pl.Expr = 'is_reg_in') -> pl.Expr:
     -------
     pl.Expr
         Aggregation expression producing the ``TRC_in`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import regression_count_in
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'is_reg_in': [None, False, False, True, False],
+    ... })
+    >>> fixations.group_by('word_idx').agg(regression_count_in()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬────────┐
+    │ word_idx ┆ TRC_in │
+    │ ---      ┆ ---    │
+    │ i64      ┆ u64    │
+    ╞══════════╪════════╡
+    │ 0        ┆ 1      │
+    │ 1        ┆ 0      │
+    │ 2        ┆ 0      │
+    └──────────┴────────┘
     """
     is_reg_in_expr = as_expr(is_reg_in)
     return is_reg_in_expr.sum().cast(pl.UInt64).alias('TRC_in')
@@ -251,6 +418,26 @@ def regression_count_out(is_reg_out: str | pl.Expr = 'is_reg_out') -> pl.Expr:
     -------
     pl.Expr
         Aggregation expression producing the ``TRC_out`` column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import regression_count_out
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'is_reg_out': [False, False, True, False, None],
+    ... })
+    >>> fixations.group_by('word_idx').agg(regression_count_out()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────────┐
+    │ word_idx ┆ TRC_out │
+    │ ---      ┆ ---     │
+    │ i64      ┆ u64     │
+    ╞══════════╪═════════╡
+    │ 0        ┆ 0       │
+    │ 1        ┆ 1       │
+    │ 2        ┆ 0       │
+    └──────────┴─────────┘
     """
     is_reg_out_expr = as_expr(is_reg_out)
     return is_reg_out_expr.sum().cast(pl.UInt64).alias('TRC_out')
@@ -278,6 +465,30 @@ def landing_position(char_idx: str | pl.Expr = 'char_idx') -> pl.Expr:
     -------
     pl.Expr
         Aggregation expression producing the ``LP`` column.
+
+    Examples
+    --------
+    The raw aggregation returns the absolute character index plus one; the pipeline later makes it
+    relative to the word start (see
+    :func:`~pymovements.measure.reading.compute_reading_measures`):
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import landing_position
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'char_idx': [0, 4, 5, 1, 8],
+    ... })
+    >>> fixations.group_by('word_idx').agg(landing_position()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬─────┐
+    │ word_idx ┆ LP  │
+    │ ---      ┆ --- │
+    │ i64      ┆ i64 │
+    ╞══════════╪═════╡
+    │ 0        ┆ 1   │
+    │ 1        ┆ 5   │
+    │ 2        ┆ 9   │
+    └──────────┴─────┘
     """
     char_idx_expr = as_expr(char_idx)
     return (char_idx_expr.first() + 1).alias('LP')
@@ -311,6 +522,29 @@ def saccade_length_in(
     -------
     pl.Expr
         Aggregation expression producing the ``SL_in`` column.
+
+    Examples
+    --------
+    Word 0 starts the sequence, so it has no entry saccade (null):
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import saccade_length_in
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'prev_word_idx': [None, 0, 1, 1, 0],
+    ...     'is_first_fix': [True, True, False, False, True],
+    ... })
+    >>> fixations.group_by('word_idx').agg(saccade_length_in()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬───────┐
+    │ word_idx ┆ SL_in │
+    │ ---      ┆ ---   │
+    │ i64      ┆ i64   │
+    ╞══════════╪═══════╡
+    │ 0        ┆ null  │
+    │ 1        ┆ 1     │
+    │ 2        ┆ 2     │
+    └──────────┴───────┘
     """
     word_idx_expr = as_expr(word_idx)
     prev_word_idx_expr = as_expr(prev_word_idx)
@@ -351,6 +585,29 @@ def saccade_length_out(
     -------
     pl.Expr
         Aggregation expression producing the ``SL_out`` column.
+
+    Examples
+    --------
+    Word 2 ends the sequence, so its exit saccade is filled with 0:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import saccade_length_out
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'next_word_idx': [1, 1, 0, 2, None],
+    ...     'run_id': [1, 2, 2, 3, 4],
+    ... })
+    >>> fixations.group_by('word_idx').agg(saccade_length_out()).sort('word_idx')
+    shape: (3, 2)
+    ┌──────────┬────────┐
+    │ word_idx ┆ SL_out │
+    │ ---      ┆ ---    │
+    │ i64      ┆ i64    │
+    ╞══════════╪════════╡
+    │ 0        ┆ 1      │
+    │ 1        ┆ -1     │
+    │ 2        ┆ 0      │
+    └──────────┴────────┘
     """
     word_idx_expr = as_expr(word_idx)
     next_word_idx_expr = as_expr(next_word_idx)
@@ -387,6 +644,31 @@ def regression_path_duration_inclusive(duration: str | pl.Expr = 'duration') -> 
     -------
     pl.Expr
         Aggregation expression producing the ``RPD_inc`` column.
+
+    Examples
+    --------
+    Grouped over ``regression_path_word``: the regression to word 0 falls inside word 1's window,
+    so its duration is included there:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import regression_path_duration_inclusive
+    >>> fixations = pl.DataFrame({
+    ...     'regression_path_word': [0, 1, 1, 1, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by('regression_path_word').agg(
+    ...     regression_path_duration_inclusive(),
+    ... ).sort('regression_path_word')
+    shape: (3, 2)
+    ┌──────────────────────┬─────────┐
+    │ regression_path_word ┆ RPD_inc │
+    │ ---                  ┆ ---     │
+    │ i64                  ┆ i64     │
+    ╞══════════════════════╪═════════╡
+    │ 0                    ┆ 100     │
+    │ 1                    ┆ 470     │
+    │ 2                    ┆ 130     │
+    └──────────────────────┴─────────┘
     """
     duration_expr = as_expr(duration)
     return duration_expr.sum().alias('RPD_inc')
@@ -419,6 +701,32 @@ def regression_path_duration_exclusive(
     -------
     pl.Expr
         Aggregation expression producing the ``RPD_exc`` column.
+
+    Examples
+    --------
+    Same window as RPD_inc but excluding fixations on the word itself, so only the regressed time
+    on word 0 (120) remains in word 1's window:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import regression_path_duration_exclusive
+    >>> fixations = pl.DataFrame({
+    ...     'regression_path_word': [0, 1, 1, 1, 2],
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by('regression_path_word').agg(
+    ...     regression_path_duration_exclusive(),
+    ... ).sort('regression_path_word')
+    shape: (3, 2)
+    ┌──────────────────────┬─────────┐
+    │ regression_path_word ┆ RPD_exc │
+    │ ---                  ┆ ---     │
+    │ i64                  ┆ i64     │
+    ╞══════════════════════╪═════════╡
+    │ 0                    ┆ 0       │
+    │ 1                    ┆ 120     │
+    │ 2                    ┆ 0       │
+    └──────────────────────┴─────────┘
     """
     duration_expr = as_expr(duration)
     word_idx_expr = as_expr(word_idx)
@@ -457,6 +765,32 @@ def right_bounded_reading_time(
     -------
     pl.Expr
         Aggregation expression producing the ``RBRT`` column.
+
+    Examples
+    --------
+    Grouped over ``regression_path_word``, summing only the fixations on the word itself (before
+    any word to its right is visited):
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import right_bounded_reading_time
+    >>> fixations = pl.DataFrame({
+    ...     'regression_path_word': [0, 1, 1, 1, 2],
+    ...     'word_idx': [0, 1, 1, 0, 2],
+    ...     'duration': [100, 200, 150, 120, 130],
+    ... })
+    >>> fixations.group_by('regression_path_word').agg(
+    ...     right_bounded_reading_time(),
+    ... ).sort('regression_path_word')
+    shape: (3, 2)
+    ┌──────────────────────┬──────┐
+    │ regression_path_word ┆ RBRT │
+    │ ---                  ┆ ---  │
+    │ i64                  ┆ i64  │
+    ╞══════════════════════╪══════╡
+    │ 0                    ┆ 100  │
+    │ 1                    ┆ 350  │
+    │ 2                    ┆ 130  │
+    └──────────────────────┴──────┘
     """
     duration_expr = as_expr(duration)
     word_idx_expr = as_expr(word_idx)
@@ -500,6 +834,24 @@ def non_aoi_fixation_count_ratio(word_idx: str | pl.Expr = 'word_idx') -> pl.Exp
     pl.Expr
         Aggregation expression producing the ``NAFCR`` column (proportion of fixations without
         a mapped word, 0.0 to 1.0).
+
+    Examples
+    --------
+    A sequence-level summary (aggregate over the whole reading sequence, not per word). Here one
+    of four fixations has a null word index:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import non_aoi_fixation_count_ratio
+    >>> fixations = pl.DataFrame({'word_idx': [0, 1, None, 2]})
+    >>> fixations.select(non_aoi_fixation_count_ratio())
+    shape: (1, 1)
+    ┌───────┐
+    │ NAFCR │
+    │ ---   │
+    │ f64   │
+    ╞═══════╡
+    │ 0.25  │
+    └───────┘
     """
     word_idx_expr = as_expr(word_idx)
     return word_idx_expr.is_null().mean().alias('NAFCR')
@@ -538,6 +890,27 @@ def non_aoi_fixation_duration_ratio(
     pl.Expr
         Aggregation expression producing the ``NAFDR`` column (proportion of fixation duration
         without a mapped word, 0.0 to 1.0).
+
+    Examples
+    --------
+    A sequence-level summary (aggregate over the whole reading sequence, not per word). The null
+    word index accounts for 50 of the 500 total duration units:
+
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import non_aoi_fixation_duration_ratio
+    >>> fixations = pl.DataFrame({
+    ...     'word_idx': [0, 1, None, 2],
+    ...     'duration': [100, 200, 50, 150],
+    ... })
+    >>> fixations.select(non_aoi_fixation_duration_ratio())
+    shape: (1, 1)
+    ┌───────┐
+    │ NAFDR │
+    │ ---   │
+    │ f64   │
+    ╞═══════╡
+    │ 0.1   │
+    └───────┘
     """
     duration_expr = as_expr(duration)
     word_idx_expr = as_expr(word_idx)


### PR DESCRIPTION
## Description

Follow-up to #1671. The declarative reading measure engine introduced there exposes each annotation expression and reading measure as a public function, but none of them had usage examples. This PR adds a runnable `Examples` section to every one of them, showing on a minimal fixation frame what column each expression produces. The examples are executed as doctests in the regular pytest run (`--doctest-modules`), so they are guaranteed to stay in sync with the implementation.

## Implemented changes

- [x] Add runnable examples to all 10 annotation expression functions in `pymovements.measure.reading.annotation` (`run_id`, `prev_word_idx`, `next_word_idx`, `delta_in`, `delta_out`, `is_reg_in`, `is_reg_out`, `is_first_fixation`, `is_first_pass`, `regression_path_word`)
- [x] Add runnable examples to all 17 reading measure functions in `pymovements.measure.reading.measures` (`total_fixation_count`, `first_pass_fixation_count`, `first_duration`, `first_reading_time`, `first_fixation_duration`, `first_pass_reading_time`, `rereading_time`, `regression_count_in`, `regression_count_out`, `landing_position`, `saccade_length_in`, `saccade_length_out`, `regression_path_duration_inclusive`, `regression_path_duration_exclusive`, `right_bounded_reading_time`, `non_aoi_fixation_count_ratio`, `non_aoi_fixation_duration_ratio`)

## How Has This Been Tested?

- [x] All 28 doctests pass locally: `pytest --doctest-modules src/pymovements/measure/reading/annotation.py src/pymovements/measure/reading/measures.py`
- [x] Doctests are part of the regular test suite via `--doctest-modules` in `pyproject.toml`, so CI runs them on every job

## Type of change

- Documentation update

## Context

#### related issues:
- #1671

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
