### PR TITLE
feat: Duration time columns follow-up

### DIFF
--- a/src/pymovements/gaze/gaze.py
+++ b/src/pymovements/gaze/gaze.py
@@ -84,7 +84,9 @@ class Gaze:
         Dictionary containing additional metadata. (default: None)
     messages: polars.DataFrame | None
         DataFrame containing messages from the experiment.
-        The required columns are 'time' and 'content'. (default: None)
+        The required columns are 'time' and 'content'. The ``time`` column is converted to a
+        ``polars.Duration`` column with microsecond precision; numeric input is interpreted
+        as milliseconds. (default: None)
     trial_columns: str | list[str] | None
         The name of the trial columns in the input data frame. If the list is empty or None,
         the input data frame is assumed to contain only one trial. If the list is not empty,
@@ -92,10 +94,14 @@ class Gaze:
         methods will be applied to each trial separately. (default: None)
     calibrations: polars.DataFrame | None
         The calibrations from the data: timestamp, num_points, tracked eye, tracking_mode.
+        A ``time`` column, if present, is converted to a ``polars.Duration`` column with
+        microsecond precision; numeric input is interpreted as milliseconds.
         None by default, to be populated by I/O helpers (e.g. from_asc). (default: None)
     validations: polars.DataFrame | None
         The validations from the data: timestamp, num_points, tracked eye, accuracy_avg,
-        accuracy_max. None by default, to be populated by I/O helpers (e.g. from_asc).
+        accuracy_max. A ``time`` column, if present, is converted to a ``polars.Duration``
+        column with microsecond precision; numeric input is interpreted as milliseconds.
+        None by default, to be populated by I/O helpers (e.g. from_asc).
         (default: None)
     time_column: str | None
         The name of the timestamp column in the input data frame. This column will be renamed to
@@ -142,7 +148,8 @@ class Gaze:
     metadata: dict[str, Any] | None
         Dictionary containing additional metadata.
     messages: polars.DataFrame | None
-        DataFrame containing messages from the experiment session.
+        DataFrame containing messages from the experiment session. The ``time`` column is
+        stored as a ``polars.Duration`` column with microsecond precision.
     trial_columns: list[str] | None
         The name of the trial columns in the samples data frame. If not None, the transformation
         methods will be applied to each trial separately.
@@ -150,10 +157,13 @@ class Gaze:
         The number of components in the pixel, position, velocity and acceleration columns.
     calibrations: polars.DataFrame | None
         The calibrations from the data: timestamp, num_points, tracked eye, tracking_mode.
+        A ``time`` column, if present, is stored as a ``polars.Duration`` column with
+        microsecond precision.
         None by default, to be populated by I/O helpers (e.g. from_asc).
     validations: polars.DataFrame | None
         The validations from the data: timestamp, num_points, tracked eye, accuracy_avg,
-        accuracy_max.
+        accuracy_max. A ``time`` column, if present, is stored as a ``polars.Duration``
+        column with microsecond precision.
         None by default, to be populated by I/O helpers (e.g. from_asc).
     schema: polars.type_aliases.SchemaDict
         Schema of the samples dataframe.
@@ -2798,10 +2808,10 @@ class Gaze:
 
     def _convert_time_units(self, time_unit: str | None) -> None:
         """Convert the time column to ``polars.Duration('us')``."""
-        # Reject an invalid unit up front: the branches below dispatch on the exact unit and the
-        # final `else` assumes 'step', so without this a typo like 'sec' would be silently handled
-        # as a step conversion. For a Duration time column the unit is ignored, but an invalid
-        # string still raises here so the same bad call fails regardless of the time column dtype.
+        # Reject an invalid unit up front: without this a typo like 'sec' would surface as an
+        # opaque KeyError from the unit lookup deep in the numeric conversion instead of a clear
+        # error. For a Duration time column the unit is ignored, but an invalid string still
+        # raises here so the same bad call fails regardless of the time column dtype.
         if time_unit not in {'s', 'ms', 'us', 'step'}:
             raise ValueError(
                 f"unsupported time unit '{time_unit}'. "

--- a/tests/unit/events/events_test.py
+++ b/tests/unit/events/events_test.py
@@ -520,6 +520,12 @@ def test_init_invalid_time_unit_raises_value_error(time_unit):
         Events(name='fixation', onsets=[5], offsets=[10], time_unit=time_unit)
 
 
+def test_init_only_data_is_positional():
+    # All parameters except data are keyword-only; passing name positionally must fail.
+    with pytest.raises(TypeError):
+        Events(pl.DataFrame(), 'fixation')  # pylint: disable=too-many-function-args
+
+
 def test_init_rounds_sub_microsecond_duration_input():
     # Sub-microsecond Duration input is rounded to the nearest microsecond, not truncated.
     events = Events(

--- a/tests/unit/gaze/gaze_save_test.py
+++ b/tests/unit/gaze/gaze_save_test.py
@@ -242,7 +242,7 @@ def test_gaze_save_metadata(tmp_path, gaze, expected_file):
             Gaze(
                 pl.DataFrame({'x': [1, 2], 'y': [3, 4]}),
                 pixel_columns=['x', 'y'],
-                calibrations=pl.DataFrame({'timestamp': [0], 'num_points': [9]}),
+                calibrations=pl.DataFrame({'time': [0], 'num_points': [9]}),
             ),
             lambda g, p: g.save_calibrations(p / 'calibrations.feather', verbose=2),
             'calibrations.feather',
@@ -252,7 +252,7 @@ def test_gaze_save_metadata(tmp_path, gaze, expected_file):
             Gaze(
                 pl.DataFrame({'x': [1, 2], 'y': [3, 4]}),
                 pixel_columns=['x', 'y'],
-                calibrations=pl.DataFrame({'timestamp': [0], 'num_points': [9]}),
+                calibrations=pl.DataFrame({'time': [0], 'num_points': [9]}),
             ),
             lambda g, p: g.save_calibrations(p / 'calibrations.csv', verbose=2),
             'calibrations.csv',
@@ -262,7 +262,7 @@ def test_gaze_save_metadata(tmp_path, gaze, expected_file):
             Gaze(
                 pl.DataFrame({'x': [1, 2], 'y': [3, 4]}),
                 pixel_columns=['x', 'y'],
-                validations=pl.DataFrame({'timestamp': [0], 'accuracy_avg': [0.5]}),
+                validations=pl.DataFrame({'time': [0], 'accuracy_avg': [0.5]}),
             ),
             lambda g, p: g.save_validations(p / 'validations.feather', verbose=2),
             'validations.feather',
@@ -272,7 +272,7 @@ def test_gaze_save_metadata(tmp_path, gaze, expected_file):
             Gaze(
                 pl.DataFrame({'x': [1, 2], 'y': [3, 4]}),
                 pixel_columns=['x', 'y'],
-                validations=pl.DataFrame({'timestamp': [0], 'accuracy_avg': [0.5]}),
+                validations=pl.DataFrame({'time': [0], 'accuracy_avg': [0.5]}),
             ),
             lambda g, p: g.save_validations(p / 'validations.csv', verbose=2),
             'validations.csv',
@@ -283,6 +283,38 @@ def test_gaze_save_metadata(tmp_path, gaze, expected_file):
 def test_gaze_save_dataframes(tmp_path, gaze, save_func, expected_file):
     save_func(gaze, tmp_path)
     assert os.path.exists(tmp_path / expected_file)
+
+
+@pytest.mark.parametrize(
+    'save_method,data',
+    [
+        pytest.param(
+            'save_calibrations',
+            pl.DataFrame({'time': [1.5], 'num_points': [9]}),
+            id='calibrations',
+        ),
+        pytest.param(
+            'save_validations',
+            pl.DataFrame({'time': [1.5], 'accuracy_avg': [0.5]}),
+            id='validations',
+        ),
+    ],
+)
+def test_gaze_save_dataframes_csv_writes_time_as_milliseconds(tmp_path, save_method, data):
+    # Numeric time input is interpreted as milliseconds and stored as Duration('us');
+    # saving to csv must write 1.5 ms back as 1.5, not the raw microsecond int 1500.
+    attribute = save_method.replace('save_', '')
+    gaze = Gaze(
+        pl.DataFrame({'x': [1, 2], 'y': [3, 4]}),
+        pixel_columns=['x', 'y'],
+        **{attribute: data},
+    )
+    path = tmp_path / f'{attribute}.csv'
+
+    getattr(gaze, save_method)(path)
+
+    written = pl.read_csv(path)
+    assert written['time'].to_list() == [1.5]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Follow-up to #1637, carrying the documentation and test changes that were split away before its merge: documents the Duration time conventions on the `Gaze` class and hardens the save and regression tests around the Duration migration. 

## Implemented changes

- [x] `Gaze` class docstrings document the Duration('us') storage and the numeric-input-is-milliseconds convention for `Gaze.messages`, `Gaze.calibrations` and `Gaze.validations`
- [x] reworded stale unit guard comment in `_convert_time_units`
- [x] calibration/validation save tests exercise `durations_to_ms` (`timestamp` -> `time`) with a round-trip milliseconds content assert
- [x] restored the keyword-only `Events.__init__` regression test

## How Has This Been Tested?

- [x] pytest on the affected suites (gaze save, events, functional gaze file processing) plus the `gaze.py` doctests: 226 passed
- [x] pre-commit clean on all changed files

## Type of change

- Documentation update

## Context

#### related issues:
- #1637

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
