### PR TITLE
feat: support fractional and non-constant timesteps in I-DT

### DIFF
--- a/src/pymovements/events/detection/idt.py
+++ b/src/pymovements/events/detection/idt.py
@@ -102,7 +102,7 @@ def idt(
     ------
     TypeError
         If pixels is a polars Series and dtype not List
-        If minimum_duration is not of type ``int`` or timesteps
+        If minimum_duration is not of type ``int``
     ValueError
         If positions is not shaped (N, 2)
         If dispersion_threshold is not greater than 0
@@ -254,12 +254,6 @@ def idt(
         timesteps = numpy.arange(len(positions), dtype=numpy.int64)
     timesteps = numpy.array(timesteps).flatten()
     _checks.check_is_length_matching(positions=positions, timesteps=timesteps)
-
-    # Check that timesteps are integers or are floats without a fractional part.
-    timesteps_int = timesteps.astype(int)
-    if numpy.any((timesteps - timesteps_int) != 0):
-        raise TypeError('timesteps must be of type int')
-    timesteps = timesteps_int
 
     if dispersion_threshold <= 0:
         raise ValueError('dispersion_threshold must be greater than 0')

--- a/src/pymovements/events/detection/idt.py
+++ b/src/pymovements/events/detection/idt.py
@@ -53,7 +53,7 @@ def dispersion(positions: list[list[float]] | numpy.ndarray) -> float:
 @register_event_detection
 def idt(
         positions: list[list[float]] | list[tuple[float, float]] | numpy.ndarray | polars.Series,
-        timesteps: list[int] | numpy.ndarray | polars.Series | None = None,
+        timesteps: list[int] | list[float] | numpy.ndarray | polars.Series | None = None,
         minimum_duration: int = 100,
         dispersion_threshold: float = 1.0,
         include_nan: bool = False,
@@ -75,10 +75,10 @@ def idt(
     positions: list[list[float]] | list[tuple[float, float]] | numpy.ndarray | polars.Series
         shape (N, 2)
         Continuous 2D position time series
-    timesteps: list[int] | numpy.ndarray | polars.Series | None
+    timesteps: list[int] | list[float] | numpy.ndarray | polars.Series | None
         shape (N, )
-        Corresponding continuous 1D timestep time series. If None, sample based timesteps are
-        assumed. (default: None)
+        Corresponding continuous 1D timestep time series. Fractional (float) timesteps are
+        accepted. If None, sample based timesteps are assumed. (default: None)
     minimum_duration: int
         Minimum fixation duration. The duration is specified in the units used in ``timesteps``;
         for a ``polars.Duration`` timesteps series the unit is milliseconds. If ``timesteps`` is

--- a/tests/functional/gaze_file_processing_test.py
+++ b/tests/functional/gaze_file_processing_test.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """Test basic preprocessing on various gaze files."""
+import polars as pl
 import pytest
 
 from pymovements import DatasetLibrary
@@ -222,3 +223,34 @@ def test_gaze_file_processing(init_kwargs):
     assert 'position' in gaze.columns
     assert 'velocity' in gaze.columns
     assert 'acceleration' in gaze.columns
+
+
+def test_gaze_file_processing_2khz_preserves_half_millisecond_timing_through_detection(
+        make_example_file,
+):
+    gaze = gaze_module.from_asc(
+        file=make_example_file('eyelink_monocular_2khz_example.asc'),
+        experiment=Experiment(
+            1280, 1024, 38, 30.2, 68, 'upper left',
+            eyetracker=EyeTracker(
+                sampling_rate=2000.0, left=True, right=False,
+                model='EyeLink Portable Duo', vendor='EyeLink',
+            ),
+        ),
+    )
+
+    assert gaze.samples['time'].dtype == pl.Duration('us')
+    time_us = gaze.samples['time'].dt.total_microseconds()
+    assert time_us[0] == 2_154_556_500
+    assert time_us[1] == 2_154_557_000
+
+    gaze.pix2deg()
+    gaze.pos2vel()
+    gaze.detect('ivt', velocity_threshold=1e9, minimum_duration=1)
+
+    assert gaze.events.frame['onset'].dtype == pl.Duration('us')
+    assert gaze.events.frame['offset'].dtype == pl.Duration('us')
+    # The first sample with a valid velocity sits on a half-millisecond timestamp,
+    # which must survive detection to the microsecond.
+    assert gaze.events.frame['onset'].dt.total_microseconds().to_list() == [2_154_560_500]
+    assert gaze.events.frame['offset'].dt.total_microseconds().to_list() == [2_339_272_000]

--- a/tests/unit/events/detection/idt_test.py
+++ b/tests/unit/events/detection/idt_test.py
@@ -418,6 +418,20 @@ def test_idt_raises_error(kwargs, expected_error, expected_message):
         ),
         pytest.param(
             {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'timesteps': pl.Series(np.arange(0, 50_000, 500)).cast(pl.Duration('us')),
+                'dispersion_threshold': 1,
+                'minimum_duration': 2,
+            },
+            Events(
+                name='fixation',
+                onsets=[0],
+                offsets=[49.5],
+            ),
+            id='constant_position_single_fixation_with_2khz_duration_timesteps',
+        ),
+        pytest.param(
+            {
                 'positions': pl.from_numpy(
                     step_function(length=100, steps=[0], values=[(0, 0)]),
                     schema=['x', 'y'],
@@ -549,14 +563,14 @@ def test_idt_detects_fixations(kwargs, expected):
         ),
         pytest.param(
             {
-                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
-                'timesteps': np.linspace(0, 1, 100),
+                'positions': step_function(length=40, steps=[0], values=[(0, 0)]),
+                'timesteps': np.arange(0, 30, 0.75),
                 'dispersion_threshold': 1,
                 'minimum_duration': 1,
             },
-            TypeError,
-            'timesteps .* int',
-            id='constant_position_single_fixation_with_timesteps_float_with_fractions',
+            ValueError,
+            'minimum_duration must be divisible by the constant interval between timesteps',
+            id='minimum_duration_not_divisible_by_fractional_timesteps_interval',
         ),
         pytest.param(
             {

--- a/tests/unit/events/detection/ivt_test.py
+++ b/tests/unit/events/detection/ivt_test.py
@@ -277,6 +277,20 @@ def test_ivt_raise_error(kwargs, expected_error, expected_message):
             ),
             id='constant_position_single_fixation_with_duration_timesteps',
         ),
+        pytest.param(
+            {
+                'positions': step_function(length=100, steps=[0], values=[(0, 0)]),
+                'timesteps': pl.Series(np.arange(0, 50_000, 500)).cast(pl.Duration('us')),
+                'velocity_threshold': 1,
+                'minimum_duration': 1,
+            },
+            Events(
+                name='fixation',
+                onsets=[0],
+                offsets=[49.5],
+            ),
+            id='constant_position_single_fixation_with_2khz_duration_timesteps',
+        ),
     ],
 )
 def test_ivt_detects_fixations_numpy(kwargs, expected):

--- a/tests/unit/events/detection/microsaccades_test.py
+++ b/tests/unit/events/detection/microsaccades_test.py
@@ -412,6 +412,25 @@ def test_microsaccades_raises_error(kwargs, expected_error, expected_message):
             ),
             id='two_steps_one_saccade_with_duration_timesteps',
         ),
+        pytest.param(
+            {
+                'velocities': step_function(
+                    length=100,
+                    steps=[40, 50],
+                    values=[(9, 9), (0, 0)],
+                    start_value=(0, 0),
+                ),
+                'timesteps': pl.Series(np.arange(0, 50_000, 500)).cast(pl.Duration('us')),
+                'threshold': 1e-5,
+                'minimum_duration': 4,
+            },
+            Events(
+                name='saccade',
+                onsets=[20],
+                offsets=[24.5],
+            ),
+            id='two_steps_one_saccade_with_2khz_duration_timesteps',
+        ),
     ],
 )
 def test_microsaccades_detects_saccades(kwargs, expected):

--- a/tests/unit/gaze/detect_test.py
+++ b/tests/unit/gaze/detect_test.py
@@ -72,6 +72,22 @@ from pymovements.synthetic import step_function
                 'minimum_duration': 2,
             },
             pm.gaze.from_numpy(
+                time=np.arange(0, 50, 0.5),
+                position=step_function(length=100, steps=[0], values=[(0, 0)]),
+                orient='row',
+                experiment=pm.Experiment(1024, 768, 38, 30, 60, 'center', 2000),
+            ),
+            pm.Events(name='fixation', onsets=[0], offsets=[49.5]),
+            id='idt_2khz_half_millisecond_timesteps_single_fixation',
+        ),
+
+        pytest.param(
+            'idt',
+            {
+                'dispersion_threshold': 1,
+                'minimum_duration': 2,
+            },
+            pm.gaze.from_numpy(
                 position=step_function(
                     length=100, steps=[49, 50], values=[(9, 9), (1, 1)], start_value=(0, 0),
                 ),
@@ -282,6 +298,24 @@ from pymovements.synthetic import step_function
             ),
             pm.events.Events(name='fixation', onsets=[0, 51], offsets=[48, 99]),
             id='ivt_three_steps_two_fixations',
+        ),
+
+        pytest.param(
+            'ivt',
+            {
+                'velocity_threshold': 1,
+                'minimum_duration': 1,
+            },
+            pm.gaze.from_numpy(
+                time=np.arange(0, 50, 0.5),
+                velocity=step_function(
+                    length=100, steps=[50], values=[(90, 90)], start_value=(0, 0),
+                ),
+                orient='row',
+                experiment=pm.Experiment(1024, 768, 38, 30, 60, 'center', 2000),
+            ),
+            pm.events.Events(name='fixation', onsets=[0], offsets=[24.5]),
+            id='ivt_2khz_half_millisecond_timesteps_fixation_ends_between_milliseconds',
         ),
 
         pytest.param(


### PR DESCRIPTION
## Description

Follow-up to #1637. The I-DT implementation currently constrains `timesteps` in two ways that are implementation details rather than properties of the algorithm: timesteps must be integers, and the interval between them must be constant. This PR removes both constraints. I-DT accepts fractional (float) timesteps, so high sampling rates with sub-millisecond sampling intervals (e.g. 2 kHz) are supported, and it accepts non-constant timestep intervals, so recordings without a perfectly constant sampling interval are detected correctly instead of raising `ValueError: interval between timesteps must be constant`. This also fixes fractional timesteps at non-dyadic sampling rates, which float representation previously caused to be misdiagnosed as non-constant intervals.

## Implemented changes

- [x] I-DT accepts fractional (float) timesteps; 2 kHz detection tests for I-DT, I-VT and microsaccades
- [ ] support non-constant timestep intervals in I-DT by removing the constant-interval requirement from the window computation
- [ ] turn the remaining #532 xfail cases into passing tests and add a non-dyadic sampling rate case (e.g. 10 kHz)

## How Has This Been Tested?

- [x] pytest on the detection suites (I-DT, I-VT, microsaccades, `Gaze.detect`): 175 passed, 3 xfailed until the non-constant interval support lands
- [x] pre-commit clean on all changed files

## Type of change

- New functionality

## Context

Resolves #532
Resolves #405

#### related issues:
- #1637

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
