### PR TITLE
fix: map Categorical and Enum dtypes to BIDS format 'string'

### DIFF
--- a/src/pymovements/dataset/_bids_dataset.py
+++ b/src/pymovements/dataset/_bids_dataset.py
@@ -116,12 +116,17 @@ def _polars_datatype_to_bids_format(dtype: polars.DataType) -> str:
         return 'bool'
     if dtype == polars.String:
         return 'string'
+    # Categorical and Enum columns hold string values, so they describe as 'string'.
+    # Note that they do not round-trip: _cast_columns_to_metadata_format casts a
+    # 'string' column back to String, matching the behaviour for loaded data.
+    if dtype in (polars.Categorical, polars.Enum):
+        return 'string'
     if dtype == polars.Null:
         return 'string'
 
     raise TypeError(
         f"polars datatype {dtype} has no mapping to bids format descriptor. "
-        f"Supported polars datatypes are: Integer, Float, String",
+        f"Supported polars datatypes are: Integer, Float, String, Categorical, Enum",
     )
 
 

--- a/tests/unit/dataset/_bids_dataset_test.py
+++ b/tests/unit/dataset/_bids_dataset_test.py
@@ -223,6 +223,19 @@ class TestBidsFormatRoundTrip:
         bids_result = _polars_datatype_to_bids_format(polars_dtype)
         assert bids_result == bids_format
 
+    @pytest.mark.parametrize(
+        'polars_dtype',
+        [
+            pytest.param(pl.Categorical, id='categorical'),
+            pytest.param(pl.Enum(['a', 'b']), id='enum'),
+        ],
+    )
+    def test_categorical_and_enum_map_to_string(self, polars_dtype):
+        # Categorical and Enum hold string values, so they describe as 'string'.
+        # They are intentionally not part of the round-trip test above: a 'string'
+        # column casts back to String, as it does for data loaded from file.
+        assert _polars_datatype_to_bids_format(polars_dtype) == 'string'
+
     def test_unknown_polars_dtype_raises(self):
         with pytest.raises(
             TypeError,

--- a/tests/unit/dataset/participants_test.py
+++ b/tests/unit/dataset/participants_test.py
@@ -92,6 +92,22 @@ def test_participants_init_data(data):
             {'participant_id': {'Format': 'string'}, 'test': {'Format': 'string'}},
             id='string',
         ),
+        pytest.param(
+            pl.DataFrame(
+                {'participant_id': ['sub-01'], 'test': ['a']},
+                schema={'participant_id': pl.String, 'test': pl.Categorical},
+            ),
+            {'participant_id': {'Format': 'string'}, 'test': {'Format': 'string'}},
+            id='categorical',
+        ),
+        pytest.param(
+            pl.DataFrame(
+                {'participant_id': ['sub-01'], 'test': ['a']},
+                schema={'participant_id': pl.String, 'test': pl.Enum(['a', 'b'])},
+            ),
+            {'participant_id': {'Format': 'string'}, 'test': {'Format': 'string'}},
+            id='enum',
+        ),
     ],
 )
 def test_participants_init_infers_correct_format(data, expected_metadata):

--- a/tests/unit/dataset/phenotype_test.py
+++ b/tests/unit/dataset/phenotype_test.py
@@ -84,6 +84,22 @@ def test_phenotype_init_data(data):
             {'participant_id': {'Format': 'string'}, 'test': {'Format': 'string'}},
             id='string',
         ),
+        pytest.param(
+            pl.DataFrame(
+                {'participant_id': ['1'], 'test': ['a']},
+                schema={'participant_id': pl.String, 'test': pl.Categorical},
+            ),
+            {'participant_id': {'Format': 'string'}, 'test': {'Format': 'string'}},
+            id='categorical',
+        ),
+        pytest.param(
+            pl.DataFrame(
+                {'participant_id': ['1'], 'test': ['a']},
+                schema={'participant_id': pl.String, 'test': pl.Enum(['a', 'b'])},
+            ),
+            {'participant_id': {'Format': 'string'}, 'test': {'Format': 'string'}},
+            id='enum',
+        ),
     ],
 )
 def test_phenotype_init_infers_correct_format(data, expected_metadata):


### PR DESCRIPTION
Closes #1716.

## Problem

`_polars_datatype_to_bids_format` raised a `TypeError` for polars `Categorical` and `Enum`, so building `Participants` or `Phenotype` from a user-constructed frame with such a column failed under the default `infer_metadata=True`:

```
TypeError: polars datatype Enum(categories=['control', 'patient']) has no mapping to bids format descriptor.
```

The only workaround, `infer_metadata=False`, silently skips format inference for every other column too.

## Change

Both dtypes hold string values, so they map to the BIDS format descriptor `'string'`, and the `TypeError` message now lists them among the supported dtypes. `_check_na_conformity` already special-cases `Categorical`/`Enum` as string-like, so this brings the two paths into agreement.

`dtype in (polars.Categorical, polars.Enum)` matches the idiom already used in `_check_na_conformity`, and covers both the bare `Categorical` and a parameterised `Enum([...])` instance.

Per the issue, the round-trip is intentionally unchanged: `_cast_columns_to_metadata_format` casts a `'string'` column back to `String`, which is the existing behaviour for data loaded from file. That is why the new dtypes are covered by a separate assertion rather than being added to `test_polars_to_bids_roundtrip`, whose `isinstance(polars_result, type(polars_dtype))` check does not hold for them.

## Tests

Added to the existing parametrize blocks rather than new standalone tests, to match the surrounding style:

- `_bids_dataset_test.py::TestBidsFormatRoundTrip::test_categorical_and_enum_map_to_string` — the direct mapping.
- `participants_test.py::test_participants_init_infers_correct_format[categorical|enum]` — public API.
- `phenotype_test.py::test_phenotype_init_infers_correct_format[categorical|enum]` — public API.

This covers all three acceptance criteria from the issue.

## Verification

- Red/green: the 6 new test cases fail on `main` (4 with the `TypeError`, 2 on the direct mapping) and pass with the change.
- Full unit suite on this branch: **4981 passed, 13 xfailed**.
- `flake8 --max-line-length=100` clean on all four changed files.
- `mypy` on `_bids_dataset.py` reports the same two pre-existing errors (lines 100 and 191) before and after the change; none are introduced here.

Sample from the issue now works:

```python
data = pl.DataFrame({
    'participant_id': ['sub-1', 'sub-2'],
    'group': pl.Series(['control', 'patient'], dtype=pl.Enum(['control', 'patient'])),
})
assert pm.Participants(data).metadata['group']['Format'] == 'string'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
