### PR TITLE
feat(measure): dedicated measure expression for skipped

### DIFF
--- a/src/pymovements/measure/reading/__init__.py
+++ b/src/pymovements/measure/reading/__init__.py
@@ -46,6 +46,7 @@ from pymovements.measure.reading.measures import rereading_time
 from pymovements.measure.reading.measures import right_bounded_reading_time
 from pymovements.measure.reading.measures import saccade_length_in
 from pymovements.measure.reading.measures import saccade_length_out
+from pymovements.measure.reading.measures import skipped
 from pymovements.measure.reading.measures import total_fixation_count
 from pymovements.measure.reading.processing import compute_reading_measures
 
@@ -82,6 +83,7 @@ __all__ = [
     'right_bounded_reading_time',
     'saccade_length_in',
     'saccade_length_out',
+    'skipped',
     'total_fixation_count',
     'non_aoi_fixation_count_ratio',
     'non_aoi_fixation_duration_ratio',

--- a/src/pymovements/measure/reading/measures.py
+++ b/src/pymovements/measure/reading/measures.py
@@ -552,3 +552,47 @@ def non_aoi_fixation_duration_ratio(
         .otherwise(None)
         .alias('NAFDR')
     )
+
+
+# ---------------------------
+# Word-level derived measures
+# ---------------------------
+
+
+def skipped(total_fixation_count: str | pl.Expr = 'TFC') -> pl.Expr:
+    """Binary indicator for total word skipping (``skipped``).
+
+    A word is skipped when it received no fixation at all. Must be evaluated
+    after join misses are zero-filled; the ``LP`` post-processing depends on
+    this column.
+
+    Parameters
+    ----------
+    total_fixation_count : str | pl.Expr
+        Column name or expression of the total fixation count.
+        (default: ``'TFC'``)
+
+    Returns
+    -------
+    pl.Expr
+        Expression producing the ``skipped`` column (1 if skipped, 0 otherwise).
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> from pymovements.measure.reading import skipped
+    >>> words = pl.DataFrame({'word': ['The', 'quick', 'brown'], 'TFC': [2, 0, 1]})
+    >>> words.with_columns(skipped())
+    shape: (3, 3)
+    ┌───────┬─────┬─────────┐
+    │ word  ┆ TFC ┆ skipped │
+    │ ---   ┆ --- ┆ ---     │
+    │ str   ┆ i64 ┆ i64     │
+    ╞═══════╪═════╪═════════╡
+    │ The   ┆ 2   ┆ 0       │
+    │ quick ┆ 0   ┆ 1       │
+    │ brown ┆ 1   ┆ 0       │
+    └───────┴─────┴─────────┘
+    """
+    total_fixation_count_expr = as_expr(total_fixation_count)
+    return (total_fixation_count_expr == 0).cast(pl.Int64).alias('skipped')

--- a/src/pymovements/measure/reading/measures.py
+++ b/src/pymovements/measure/reading/measures.py
@@ -559,7 +559,7 @@ def non_aoi_fixation_duration_ratio(
 # ---------------------------
 
 
-def skipped(total_fixation_count: str | pl.Expr = 'TFC') -> pl.Expr:
+def skipped(tfc: str | pl.Expr = 'TFC') -> pl.Expr:
     """Binary indicator for total word skipping (``skipped``).
 
     A word is skipped when it received no fixation at all. Must be evaluated
@@ -568,7 +568,7 @@ def skipped(total_fixation_count: str | pl.Expr = 'TFC') -> pl.Expr:
 
     Parameters
     ----------
-    total_fixation_count : str | pl.Expr
+    tfc : str | pl.Expr
         Column name or expression of the total fixation count.
         (default: ``'TFC'``)
 
@@ -594,5 +594,5 @@ def skipped(total_fixation_count: str | pl.Expr = 'TFC') -> pl.Expr:
     │ brown ┆ 1   ┆ 0       │
     └───────┴─────┴─────────┘
     """
-    total_fixation_count_expr = as_expr(total_fixation_count)
-    return (total_fixation_count_expr == 0).cast(pl.Int64).alias('skipped')
+    tfc_expr = as_expr(tfc)
+    return (tfc_expr == 0).cast(pl.Int64).alias('skipped')

--- a/src/pymovements/measure/reading/processing.py
+++ b/src/pymovements/measure/reading/processing.py
@@ -41,6 +41,7 @@ from pymovements.measure.reading.measures import rereading_time
 from pymovements.measure.reading.measures import right_bounded_reading_time
 from pymovements.measure.reading.measures import saccade_length_in
 from pymovements.measure.reading.measures import saccade_length_out
+from pymovements.measure.reading.measures import skipped
 from pymovements.measure.reading.measures import total_fixation_count
 
 # Measure output columns, in order. Group columns and word identity are prepended on output.
@@ -725,8 +726,7 @@ def _assemble_word_level_measures(
     table = table.with_columns(
         [pl.col(column).fill_null(0) for column in joined_measure_columns],
     ).with_columns(
-        # total skipping: the word received no fixation at all
-        (pl.col('TFC') == 0).cast(pl.Int64).alias('skipped'),
+        skipped(),
     )
 
     if 'LP' in table.columns:

--- a/tests/unit/measure/reading/reading_measures_test.py
+++ b/tests/unit/measure/reading/reading_measures_test.py
@@ -512,11 +512,13 @@ def test_skipped_default_column():
         'TFC': [2, 0, 1, 0],
     })
     result = df.with_columns(skipped())
-    expected = pl.DataFrame({
-        'word': ['The', 'quick', 'brown', 'fox'],
-        'TFC': [2, 0, 1, 0],
-        'skipped': [0, 1, 0, 1],
-    }, schema_overrides={'skipped': pl.Int64})
+    expected = pl.DataFrame(
+        {
+            'word': ['The', 'quick', 'brown', 'fox'],
+            'TFC': [2, 0, 1, 0],
+            'skipped': [0, 1, 0, 1],
+        }, schema_overrides={'skipped': pl.Int64},
+    )
     assert_frame_equal(result, expected)
 
 
@@ -527,11 +529,13 @@ def test_skipped_custom_column_string_and_expr():
     })
     res1 = df.with_columns(skipped('my_count'))
     res2 = df.with_columns(skipped(pl.col('my_count')))
-    expected = pl.DataFrame({
-        'word': ['a', 'b'],
-        'my_count': [0, 5],
-        'skipped': [1, 0],
-    }, schema_overrides={'skipped': pl.Int64})
+    expected = pl.DataFrame(
+        {
+            'word': ['a', 'b'],
+            'my_count': [0, 5],
+            'skipped': [1, 0],
+        }, schema_overrides={'skipped': pl.Int64},
+    )
     assert_frame_equal(res1, expected)
     assert_frame_equal(res2, expected)
 

--- a/tests/unit/measure/reading/reading_measures_test.py
+++ b/tests/unit/measure/reading/reading_measures_test.py
@@ -42,6 +42,7 @@ from pymovements.measure.reading.measures import rereading_time
 from pymovements.measure.reading.measures import right_bounded_reading_time
 from pymovements.measure.reading.measures import saccade_length_in
 from pymovements.measure.reading.measures import saccade_length_out
+from pymovements.measure.reading.measures import skipped
 from pymovements.measure.reading.measures import total_fixation_count
 from pymovements.measure.reading.processing import compute_reading_measures
 from pymovements.stimulus.text import TextStimulus
@@ -503,3 +504,43 @@ def test_non_aoi_fixation_duration_ratio(fixations, expected):
         non_aoi_fixation_duration_ratio(),
     )
     assert_frame_equal(result, expected, abs_tol=1e-5)
+
+
+def test_skipped_default_column():
+    df = pl.DataFrame({
+        'word': ['The', 'quick', 'brown', 'fox'],
+        'TFC': [2, 0, 1, 0],
+    })
+    result = df.with_columns(skipped())
+    expected = pl.DataFrame({
+        'word': ['The', 'quick', 'brown', 'fox'],
+        'TFC': [2, 0, 1, 0],
+        'skipped': [0, 1, 0, 1],
+    }, schema_overrides={'skipped': pl.Int64})
+    assert_frame_equal(result, expected)
+
+
+def test_skipped_custom_column_string_and_expr():
+    df = pl.DataFrame({
+        'word': ['a', 'b'],
+        'my_count': [0, 5],
+    })
+    res1 = df.with_columns(skipped('my_count'))
+    res2 = df.with_columns(skipped(pl.col('my_count')))
+    expected = pl.DataFrame({
+        'word': ['a', 'b'],
+        'my_count': [0, 5],
+        'skipped': [1, 0],
+    }, schema_overrides={'skipped': pl.Int64})
+    assert_frame_equal(res1, expected)
+    assert_frame_equal(res2, expected)
+
+
+def test_skipped_empty_dataframe():
+    df = pl.DataFrame({'TFC': pl.Series([], dtype=pl.Int64)})
+    result = df.with_columns(skipped())
+    expected = pl.DataFrame({
+        'TFC': pl.Series([], dtype=pl.Int64),
+        'skipped': pl.Series([], dtype=pl.Int64),
+    })
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
## Description

This PR extracts the \skipped\ measure derivation into a dedicated public expression function \skipped()\ in \pymovements.measure.reading.measures\, as requested in #1720. It replaces the inline derivation in \compute_reading_measures\ while documenting and preserving the ordering contract (zero-fill join misses, evaluate \skipped\, then execute \LP\ post-processing based on \skipped == 1\).

## Implemented changes

- [x] Add \skipped(total_fixation_count: str | pl.Expr = 'TFC') -> pl.Expr\ in \pymovements.measure.reading.measures\ with docstrings, runnable doctest example, and explicit documentation of the \LP\ ordering contract.
- [x] Export \skipped\ in \pymovements.measure.reading\.
- [x] Use \skipped()\ inside \_assemble_word_level_measures()\ in \processing.py\, removing the inline \(pl.col('TFC') == 0).cast(pl.Int64).alias('skipped')\.
- [x] Add unit tests in \eading_measures_test.py\ covering default column \'TFC'\, custom column name / expression, and empty DataFrame behavior.

## How Has This Been Tested?

- [x] Unit tests pass: \pytest tests/unit/measure/reading/reading_measures_test.py\
- [x] Full reading measure processing pipeline tests pass: \pytest tests/unit/measure/reading/processing_test.py\
- [x] Doctests pass: \pytest --doctest-modules src/pymovements/measure/reading/measures.py\
- [x] Flake8 style checks pass with 0 warnings.

## Type of change

- New functionality

## Context

Resolves #1720

#### related issues:
- #1671
- #1721

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings