### PR TITLE
docs: PMEP 1: exact event durations and change minimal schema

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,31 @@
+# Governance
+
+pymovements has many more contributors than the people listed here. The full credit list is
+[`CITATION.cff`](CITATION.cff) and the
+[contributors graph](https://github.com/pymovements/pymovements/graphs/contributors).
+
+## Core contributors
+
+Core contributors vote on pymovements Enhancement Proposals (see
+`docs/source/pmep/pmep-000-purpose-process-governance.md`). Core contributors are people with
+sustained, design-level involvement across the project (code, review, or research direction),
+not a commit-count threshold. Additions are proposed by any core contributor and accepted like
+a PMEP.
+
+A core contributor without repository or governance activity (commit, review, issue or pull
+request comment, vote, design-review attendance) for 12 months becomes emeritus: credit kept,
+no vote, active status restored on request. The lead maintainer flags the transition as an
+editorial change, with prior private notice.
+
+**Lead maintainer:** Daniel Krakowczyk ([@dkrako](https://github.com/dkrako))
+
+| Name | GitHub | Status |
+|---|---|---|
+| Daniel Krakowczyk | [@dkrako](https://github.com/dkrako) | active |
+| David R. Reich | [@SiQube](https://github.com/SiQube) | active |
+| Carlson Büth | [@cbueth](https://github.com/cbueth) | active |
+| Andreas Säuberli | [@saeub](https://github.com/saeub) | active |
+| Paul Prasse | [@prassepaul](https://github.com/prassepaul) | active |
+| Deborah N. Jakobi | [@theDebbister](https://github.com/theDebbister) | active |
+| Paweł Kasprowski | [@kasprowski](https://github.com/kasprowski) | active |
+| Lena Jäger | | emeritus |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,10 +7,9 @@ pymovements has many more contributors than the people listed here. The full cre
 ## Core contributors
 
 Core contributors vote on pymovements Enhancement Proposals (see
-`docs/source/pmep/pmep-000-purpose-process-governance.md`). Core contributors are people with
+`docs/source/pmep/pmep-000-purpose-process-governance.md`). Core contributor status reflects
 sustained, design-level involvement across the project (code, review, or research direction),
-not a commit-count threshold. Additions are proposed by any core contributor and accepted like
-a PMEP.
+not a commit count. Additions are proposed by any core contributor and accepted like a PMEP.
 
 A core contributor without repository or governance activity (commit, review, issue or pull
 request comment, vote, design-review attendance) for 12 months becomes emeritus: credit kept,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-# exclude_patterns = []
+exclude_patterns = ['pmep/TEMPLATE.md']
 suppress_warnings = [
     'myst.header',
 ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,5 +15,6 @@ Welcome to the pymovements documentation!
    datasets/index
    reference/index
    contributing/index
+   pmep/index
    about-us/index
    bibliography

--- a/docs/source/pmep/TEMPLATE.md
+++ b/docs/source/pmep/TEMPLATE.md
@@ -1,0 +1,66 @@
+# PMEP NNN: Short title
+
+<!-- Copy to docs/source/pmep/pmep-NNN-short-title.md. The number is assigned
+     when the pull request opens (next free number). -->
+
+| | |
+|---|---|
+| **Status** | Draft |
+| **Type** | Standards / Process |
+| **Author** | |
+| **Created** | YYYY-MM-DD |
+| **Supersedes** | none |
+
+## TL;DR
+
+<!-- Mandatory before voting opens. At most 150 words or 5 bullets. What changes,
+     in a form someone can read in under a minute and vote on. A summary of the
+     decision, not of the document. -->
+
+## What it looks like
+
+<!-- Mandatory before voting opens. Code, before and after: the smallest realistic
+     example of the change in use. -->
+
+```python
+# before
+```
+
+```python
+# after
+```
+
+## Resulting signatures
+
+<!-- Mandatory before voting opens. The public signatures the proposal produces,
+     written out: constructors, method signatures, dataclass fields, file-format
+     schemas. Only if the proposal defines a file format or on-disk layout:
+     write out its structure and give it an initial schema version carried in
+     the artifact itself. -->
+
+## Motivation
+
+<!-- The problem, with a concrete instance. Not "this would be cleaner". -->
+
+## Specification
+
+<!-- The normative part. What changes, precisely enough to implement. -->
+
+## Rationale
+
+<!-- Why this design and not the alternatives, including alternatives rejected. -->
+
+## Backwards compatibility
+
+<!-- What breaks, the deprecation path, the version the deprecation lands in, and
+     the computed removal version under the project's deprecation window
+     (currently five minor releases, and any window still open at 1.0 closes
+     there). -->
+
+## Implementation
+
+<!-- A rough list of work items while the proposal is under review. After
+     acceptance the items become issues, each linking back here (adding the
+     numbers is editorial). All boxes checked moves the status to Final. -->
+
+- [ ]

--- a/docs/source/pmep/index.rst
+++ b/docs/source/pmep/index.rst
@@ -1,0 +1,16 @@
+=======================
+ Enhancement Proposals
+=======================
+
+Larger changes to pymovements are decided through pymovements Enhancement Proposals (PMEPs).
+:doc:`PMEP 0 <pmep-000-purpose-process-governance>` defines which changes need a proposal and
+how one is accepted. The core contributor list lives in
+`GOVERNANCE.md <https://github.com/pymovements/pymovements/blob/main/GOVERNANCE.md>`_.
+New proposals start from the :doc:`template <template>`.
+
+.. toctree::
+    :glob:
+    :maxdepth: 1
+
+    pmep-*
+    template

--- a/docs/source/pmep/pmep-000-purpose-process-governance.md
+++ b/docs/source/pmep/pmep-000-purpose-process-governance.md
@@ -1,0 +1,115 @@
+# PMEP 0: How we decide larger changes
+
+| | |
+|---|---|
+| **Status** | Draft |
+| **Type** | Process |
+| **Author** | Daniel Krakowczyk |
+| **Created** | 2026-09-08 |
+
+## TL;DR
+
+Changes that many other things depend on (the data model, operation contracts, on-disk
+formats, this process) require a PMEP: a design document in `docs/source/pmep/`,
+proposed and decided in a pull request. Acceptance needs a window of 14 days, 2 approvals
+from active core contributors other than the author, and no unresolved objection. The lead
+maintainer may override objections but not the approval floor. Core contributors are listed
+in `GOVERNANCE.md`. Everything else keeps the usual issue and PR workflow.
+
+Several changes to the data model and the operation layer are upcoming. This page states how
+they get decided, so that the reasoning is written down once and can be cited later instead of
+reconstructed from issue threads.
+
+## What needs a proposal
+
+A **PMEP** (pymovements Enhancement Proposal) is required only for changes that many other
+things depend on:
+
+- the data model: containers, slots, how recordings, events, stimuli and measures are represented
+- contracts every operation or pipeline follows: operation contract, registry, column declarations, log format
+- on-disk formats and layouts that published datasets depend on
+- this process
+
+Adding an attribute to an existing class needs a PMEP only if readers, writers or operations
+must account for it, not if it is local to the class.
+
+Everything else, including breaking changes to individual functions or classes, is an issue,
+a pull request, a changelog entry, and the usual five-minor-release deprecation window.
+When in doubt, open an issue. It graduates to a PMEP if the discussion shows it needs one.
+
+Work already in review or on an agreed issue when this process is adopted is grandfathered:
+no PMEP is required for it retroactively.
+
+## Where they live
+
+`docs/source/pmep/pmep-NNN-short-title.md`, opened as a pull request and rendered in the
+documentation. The number is assigned when the pull request opens, so the proposal can be
+cited by number during discussion. The pull request stays open until the decision falls and
+merges carrying the final status. Rejected and withdrawn PMEPs are merged too and stay in the
+repository as records of what was considered and why not.
+
+Status is one of: Draft · Accepted · Final (implemented) · Rejected · Withdrawn · Superseded.
+
+## Who decides
+
+**Core contributors** are listed in `GOVERNANCE.md` and have the right to vote. Anyone may
+comment. The entry
+criterion, additions to the list and the emeritus rule are defined in `GOVERNANCE.md`.
+
+**The lead maintainer decides objections.** An unresolved objection may be overridden. The
+override is written into the PMEP with reasoning and answers the objection on its merits.
+The approval requirement below is a hard floor and cannot be overridden.
+
+## How a PMEP is accepted
+
+Votes are cast as GitHub reviews on the pull request: an approving review counts as an
+approval, a request for changes as an objection. The acceptance window starts when the author
+marks the pull request ready for review.
+
+1. Open at least 14 days since the last substantive revision.
+2. At least 2 approvals from active core contributors other than the author(s).
+3. No unresolved objection.
+
+An objection must state a technical reason concrete enough to be addressed. It does not have
+to propose the fix. An objection without such a reason does not block.
+
+An objection is resolved when withdrawn, when addressed in the text and not renewed within
+7 days, or when overridden by the lead maintainer. After 30 days without quorum the author
+pings the active core contributors. Nothing changes state automatically.
+
+A PMEP may be discussed in a scheduled design review meeting. The meeting does not shorten
+the 14 day window, votes still count only as GitHub reviews on the pull request, and
+decisions or objections from the meeting are written into the PMEP within a week.
+
+A substantive change to an *Accepted* PMEP reopens a 7 day window and needs 1 approval.
+Editorial changes need none.
+
+## What a PMEP must contain
+
+In this order:
+
+- **TL;DR** (at most 150 words)
+- **What it looks like** (code, before and after)
+- **Resulting signatures** (written out, with schema versions for file formats)
+- Motivation
+- Specification
+- Rationale, including rejected alternatives
+- Backwards compatibility (deprecation version, computed removal version)
+- Implementing issues
+
+This structure is for Standards PMEPs. Process PMEPs adapt it and keep what applies.
+
+The first three are mandatory before voting opens. A reviewer should be able to form a view in
+five minutes from them alone. `docs/source/pmep/TEMPLATE.md` has them stubbed.
+
+## Relationship to issues and PRs
+
+A PMEP specifies. Issues carry it out and link back. PRs implementing an accepted PMEP cite it,
+and may be declined for diverging from it without reopening the design. If implementation shows
+the spec is wrong, the PMEP is revised.
+
+## Adoption
+
+This PMEP is adopted under its own rule: 14 days, 2 approvals from active core contributors
+other than the author, no unresolved objection. The initial core contributor list in
+`GOVERNANCE.md` is accepted with it.

--- a/docs/source/pmep/template.rst
+++ b/docs/source/pmep/template.rst
@@ -1,0 +1,8 @@
+==========
+ Template
+==========
+
+New proposals start from this template, located at ``docs/source/pmep/TEMPLATE.md``:
+
+.. literalinclude:: TEMPLATE.md
+    :language: markdown


### PR DESCRIPTION
## Description

PMEP 1, the first slice of the data-model proposal series: the minimal `Events` schema
becomes `onset`, `duration`, `name`. `offset` leaves the stored schema and becomes an
on-demand measure with an `inclusive` parameter. Durations become exact (matching EyeLink's
reported `DUR`); today's derived `offset - onset` is one sampling interval short everywhere.

Opened as a draft for the design review; per PMEP 0, the 14-day acceptance window starts at
ready-for-review. The series overview Discussion will be linked from the document once posted.

## Implemented changes

- [x] `docs/source/pmep/pmep-001-events-minimal-schema.md` following the PMEP template
- [x] One marked open question for the design review (events-frame granularity), to be
      folded in before ready-for-review

## How Has This Been Tested?

- [ ] Documentation build renders the new page (picked up by the `pmep-*` glob in the index)

## Type of change

- Documentation update (the proposal itself specifies a breaking change for v0.29.0)

## Context

Resolves #1677

#### related issues:
- #1083 (closed by the proposed `durations=` constructor path)
- #1637 (ships in the same v0.29.0 release)
- #1663, #969 (couplings checked, no reordering needed)

#### required by:
- #1563

#### requires:
- [ ] #1723 (PMEP 0: process this proposal is decided under; branch is stacked on it)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
